### PR TITLE
Remove Magit dependency, add Dired toggle image thumbnail

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,12 +54,15 @@ More detail on Anju's features can be found in the [[https://kickingvegas.github
 :PROPERTIES:
 :CUSTOM_ID: requirements
 :END:
-Anju requires Emacs 29.1+, Magit 4.4+, Casual 2.13+, Markdown Mode 2.7+.
+Anju requires Emacs 29.1+, Casual 2.13+, Markdown Mode 2.7+.
 
 Certain menus require more installed software:
 
 - Anju Dired Support: GNU Coreutils (~ls~)
 - Markdown import to Org: pandoc
+
+Anju provides optional support for Magit 4.4+.
+    
 
 * Install
 :PROPERTIES:

--- a/docs/anju.org
+++ b/docs/anju.org
@@ -195,12 +195,15 @@ Anju has context menu support for Dired mode. The screenshot below shows the con
 
 [[file:images/anju-dired-copy-to.png]]
 
-
 If the mouse point is over a directory, the option to insert a view (aka subdir) for it in the buffer is provided.
 
 [[file:images/anju-dired-insert-subdir.png]]
 
 Note that the Dired context menu is intentionally restrained in its command offering in accord with Anju's [[#design-principles][Design Principles and Concerns]].
+
+*** Magit Support
+
+If Magit 4.4+ is installed, then the context menu function ~anju-context-menu-vc~ will offer Magit commands depending on context. If the context menu is raised in a file buffer, then the menu item "Magit Dispatch…" (~magit-file-dispatch~) is shown, otherwise "Magit Status" (~magit-status~).
 
 
 ** Main Menu
@@ -227,17 +230,18 @@ Anju provides support for customizing the enhancements ([[#main-menu-customizati
 Window management via mouse interaction is provided for through the [[#mode-line][mode line]] and [[#context-menu][context menu]]. More detail is provided in those sections.
 
 
-
 * Requirements
 #+CINDEX: Requirements
 
-Anju requires Emacs 29.1+, Magit 4.4+, Casual 2.13+, Markdown Mode 2.7+.
+Anju requires Emacs 29.1+, Casual 2.13+, Markdown Mode 2.7+.
 
 Certain menus require more installed software:
 
 - Anju Dired Support: GNU Coreutils (~ls~)
 - Markdown import to Org: pandoc
 
+Anju provides optional support for Magit 4.4+.
+  
 * Install
 #+CINDEX: Install
 #+VINDEX: context-menu-mode
@@ -386,6 +390,44 @@ It is recommended to use the ~customize-variable~ command to configure ~context-
 1. A visual UI is provided showing what choices for built-in context menu functions are available.
 2. Users can insert their own custom function.
 3. Top-down ordering of functions will similarly determine the order of menu items in the context menu.
+
+*** Anju Context Menu Functions
+#+VINDEX: anju-context-menu-dired
+#+VINDEX: anju-context-menu-org-mode
+#+VINDEX: anju-context-menu-scratch
+#+VINDEX: anju-context-menu-buffers
+#+VINDEX: anju-context-menu-region
+#+VINDEX: anju-context-menu-narrow
+#+VINDEX: anju-context-menu-open-in
+#+VINDEX: anju-context-menu-vc
+#+VINDEX: anju-context-menu-markup
+#+VINDEX: anju-context-menu-wordcount
+#+VINDEX: anju-context-menu-window
+                     
+Anju provides the following context menu functions for convenience. They can be used as-is or serve as a base for user-customized behavior.
+
+- ~anju-context-menu-dired~ :: Dired commands.
+
+- ~anju-context-menu-org-mode~  :: Org mode commands.
+
+- ~anju-context-menu-scratch~  :: Open scratch buffer.
+
+- ~anju-context-menu-buffers~ :: Buffer navigation commands.
+
+- ~anju-context-menu-region~ :: Commands for selected text.
+
+- ~anju-context-menu-narrow~ :: Narrow-related commands.
+
+- ~anju-context-menu-open-in~ :: Open in Dired.
+
+- ~anju-context-menu-vc~ :: Version control related commands.
+  If Magit 4.4+ is installed, then calls to it are made from here.
+
+- ~anju-context-menu-markup~ :: Commands to show/hide text markup (e.g. Org, Markdown).
+
+- ~anju-context-menu-wordcount~ :: Word count command.
+
+- ~anju-context-menu-window~ :: Window management commands.
 
 ** Mode Line Buffer List Menu Customization
 :PROPERTIES:

--- a/docs/anju.texi
+++ b/docs/anju.texi
@@ -50,11 +50,11 @@ Support direct manipulation when possible
 Re-organization of the main menu bar
 @end itemize
 
-The features offered by Anju are opinionated, but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
+The features offered by Anju are opinionated@comma{} but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
 
 Please note that all UI terminology in this document is Emacs-centric and differs from conventional GUI terminology. Refer to (emacs) Frames (@ref{Frames,emacs#Frames,,emacs,}) for more detail on this.
 
-It costs money to make, enhance, and maintain Anju as ideologically free software. If you enjoy using Anju, please buy me a coffee to help support its development and maintenance.
+It costs money to make@comma{} enhance@comma{} and maintain Anju as ideologically free software. If you enjoy using Anju@comma{} please buy me a coffee to help support its development and maintenance.
 
 @image{images/default-yellow,,,,png}
 
@@ -94,6 +94,7 @@ Context Menu
 
 * Org Mode Context Menu::
 * Dired Mode Context Menu::
+* Magit Support::
 
 Customization
 
@@ -101,6 +102,10 @@ Customization
 * Context Menu Customization::
 * Mode Line Buffer List Menu Customization::
 * Main Menu Customization::
+
+Context Menu Customization
+
+* Anju Context Menu Functions::
 
 @end detailmenu
 @end menu
@@ -123,7 +128,7 @@ Lengthy menus that feel more like an inventory of commands rather than a designe
 Over-reliance on mouse workflows that require switching between the mouse and keyboard.
 @end itemize
 
-Anju makes opinionated design decisions, but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
+Anju makes opinionated design decisions@comma{} but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
 
 Elaboration on what informs Anju's opinions is described below.
 
@@ -138,7 +143,7 @@ Elaboration on what informs Anju's opinions is described below.
 
 This section conveys the principles and concerns used by Anju to inform its design decisions.
 
-Editorially, all design decisions for Anju are ultimately the opinion of Charles Y@. Choi.
+Editorially@comma{} all design decisions for Anju are ultimately the opinion of Charles Y@. Choi.
 
 
 @subheading General Principles
@@ -153,18 +158,18 @@ A coherent information architecture should be conveyed.
 Balance between concision and discoverability should be made in a menu's offerings.
 @end itemize
 @item
-Nesting of sub-menus should be carefully considered, ideally not exceeding a depth of two.
+Nesting of sub-menus should be carefully considered@comma{} ideally not exceeding a depth of two.
 @item
 Mouse workflows that require keyboard input should be minimized.
 @item
-If the opportunity to provide a direct manipulation experience is available, it should be taken.
+If the opportunity to provide a direct manipulation experience is available@comma{} it should be taken.
 @item
 Unconventional mouse interactions should be avoided.
 @end itemize
 
 @subheading Concerns
 
-Anju takes the position that different types of menus have different concerns or objectives. This is most apparent in contrasting the design of a main menu section (e.g. File, Edit, Options, …) to that of a context menu.
+Anju takes the position that different types of menus have different concerns or objectives. This is most apparent in contrasting the design of a main menu section (e.g. File@comma{} Edit@comma{} Options@comma{} …) to that of a context menu.
 
 For Anju:
 
@@ -175,7 +180,7 @@ The highest concern of a main menu section is discoverability.
 The highest concern of a context menu is concision.
 @end itemize
 
-A common implementation practice in Emacs is to reuse menu keymaps for both the main menu and context menus. This violates the above concerns, which Anju seeks to address.
+A common implementation practice in Emacs is to reuse menu keymaps for both the main menu and context menus. This violates the above concerns@comma{} which Anju seeks to address.
 
 The next sub-sections further detail the design concerns with respect to an area where mouse interaction occurs.
 
@@ -200,11 +205,11 @@ Anju takes the opinion that context menus should @emph{not} support general comm
 
 @subsubheading Direct Manipulation
 
-Support for direct action based on mouse cursor position is a common user interaction technique. Anju applies this to Emacs window management, where window creation, deletion, and swapping are supported from both the context menu and the mode line.
+Support for direct action based on mouse cursor position is a common user interaction technique. Anju applies this to Emacs window management@comma{} where window creation@comma{} deletion@comma{} and swapping are supported from both the context menu and the mode line.
 
 @subsubheading No Middle Button Bindings
 
-Anju eschews Emacs' default middle mouse button bindings as they presume usage of a @uref{https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Sun_optical_mouse.jpg/960px-Sun_optical_mouse.jpg, 90's style 3-button mouse}. This style of mouse design has long been superseded with a middle @uref{https://upload.wikimedia.org/wikipedia/commons/2/22/3-Tasten-Maus_Microsoft.jpg, scroll-wheel+button control}. This widespread hardware change has resulted in the majority of mouse-supporting applications to emphasize scrolling actions with the middle control and clicking actions to the left and right buttons. Anju follows suit, primarily binding the right mouse button click (down) event to raising a context menu. In addition, Anju reconfigures commands that were previously bound to the middle button to ones accessible via a context menu.
+Anju eschews Emacs' default middle mouse button bindings as they presume usage of a @uref{https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Sun_optical_mouse.jpg/960px-Sun_optical_mouse.jpg, 90's style 3-button mouse}. This style of mouse design has long been superseded with a middle @uref{https://upload.wikimedia.org/wikipedia/commons/2/22/3-Tasten-Maus_Microsoft.jpg, scroll-wheel+button control}. This widespread hardware change has resulted in the majority of mouse-supporting applications to emphasize scrolling actions with the middle control and clicking actions to the left and right buttons. Anju follows suit@comma{} primarily binding the right mouse button click (down) event to raising a context menu. In addition@comma{} Anju reconfigures commands that were previously bound to the middle button to ones accessible via a context menu.
 
 The only exception Anju makes in this matter is to keep the Emacs default binding of @code{mouse-2} to @code{mouse-yank-primary}.
 
@@ -232,7 +237,7 @@ The following mode line enhancements are provided by Anju:
 @subheading Pop-up Buffer List
 @cindex Pop-up Buffer List
 
-On the mode line, left-click (@code{mouse-1}) on the buffer name to raise a pop-up menu containing a list of open buffers. The contents of this list is controlled by the customizable variable @code{anju-buffer-list-filter-functions}. More info on customizing the buffer list menu can be found in @ref{Mode Line Buffer List Menu Customization}.
+On the mode line@comma{} left-click (@code{mouse-1}) on the buffer name to raise a pop-up menu containing a list of open buffers. The contents of this list is controlled by the customizable variable @code{anju-buffer-list-filter-functions}. More info on customizing the buffer list menu can be found in @ref{Mode Line Buffer List Menu Customization, , Mode Line Buffer List Menu Customization}.
 
 
 @image{images/anju-mode-line-buffer-list,,,,png}
@@ -244,7 +249,7 @@ A right-click (@code{mouse-3}) on any blank space on the mode line will pop-up a
 
 @image{images/anju-mode-line-window-management,,,,png}
 
-From here, one can:
+From here@comma{} one can:
 @itemize
 @item
 Delete the window (×)
@@ -253,7 +258,7 @@ Split the window horizontally (→)
 @item
 Split the window vertically (↓)
 @item
-If multiple windows are shown, swap the current window.
+If multiple windows are shown@comma{} swap the current window.
 @end itemize
 
 Note: usage of ``window'' refers to the Emacs definition of it. Refer to @ref{Frames,emacs#Frames,,emacs,} for more detail on this.
@@ -261,7 +266,7 @@ Note: usage of ``window'' refers to the Emacs definition of it. Refer to @ref{Fr
 @subheading Toggle Maximize Window
 @cindex Toggle Maximize Window
 
-A left-double-click on any blank space on the mode line will checkpoint the current window configuration, then maximize the current window (@code{delete-other-windows}). Re-doing the left-double-click will restore the prior window configuration.
+A left-double-click on any blank space on the mode line will checkpoint the current window configuration@comma{} then maximize the current window (@code{delete-other-windows}). Re-doing the left-double-click will restore the prior window configuration.
 
 @node Context Menu
 @section Context Menu
@@ -275,9 +280,9 @@ Anju both works with and enhances @code{context-menu-mode} to support features l
 Selected Text Commands
 @itemize
 @item
-Style (bold, italic, code, etc.)
+Style (bold@comma{} italic@comma{} code@comma{} etc.)
 @item
-Transform Text (upper/lower case, capitalize)
+Transform Text (upper/lower case@comma{} capitalize)
 @item
 Occur
 @item
@@ -299,11 +304,11 @@ Window management based on mouse position
 Full support for @code{context-menu-mode} customization using @code{context-menu-functions}.
 @itemize
 @item
-See @ref{Context Menu Customization} for more info.
+See @ref{Context Menu Customization, , Context Menu Customization} for more info.
 @end itemize
 @end itemize
 
-Anju is planned to have on-going development, with more commands and modes supported in future releases.
+Anju is planned to have on-going development@comma{} with more commands and modes supported in future releases.
 
 Shown below is an screenshot of a context menu when text is selected.
 
@@ -312,16 +317,17 @@ Shown below is an screenshot of a context menu when text is selected.
 @menu
 * Org Mode Context Menu::
 * Dired Mode Context Menu::
+* Magit Support::
 @end menu
 
 @node Org Mode Context Menu
 @subsection Org Mode Context Menu
 
-The screenshot below shows a context menu for Org mode. Note that the upper part of the menu changes with respect to what kind of Org element (in the example below, a list item) the point is on.
+The screenshot below shows a context menu for Org mode. Note that the upper part of the menu changes with respect to what kind of Org element (in the example below@comma{} a list item) the point is on.
 
 @image{images/anju-context-menu-org-mode,,,,png}
 
-Note that the Org mode context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns}.
+Note that the Org mode context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns, , Design Principles and Concerns}.
 
 @node Dired Mode Context Menu
 @subsection Dired Mode Context Menu
@@ -330,12 +336,16 @@ Anju has context menu support for Dired mode. The screenshot below shows the con
 
 @image{images/anju-dired-copy-to,,,,png}
 
-
-If the mouse point is over a directory, the option to insert a view (aka subdir) for it in the buffer is provided.
+If the mouse point is over a directory@comma{} the option to insert a view (aka subdir) for it in the buffer is provided.
 
 @image{images/anju-dired-insert-subdir,,,,png}
 
-Note that the Dired context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns}.
+Note that the Dired context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns, , Design Principles and Concerns}.
+
+@node Magit Support
+@subsection Magit Support
+
+If Magit 4.4+ is installed@comma{} then the context menu function @code{anju-context-menu-vc} will offer Magit commands depending on context. If the context menu is raised in a file buffer@comma{} then the menu item ``Magit Dispatch…'' (@code{magit-file-dispatch}) is shown@comma{} otherwise ``Magit Status'' (@code{magit-status}).
 
 @node Main Menu
 @section Main Menu
@@ -344,7 +354,7 @@ Anju offers the following enhancements to the main menu:
 
 @subheading Bookmarks menu
 
-To support usage of Emacs bookmarks, the following menu is added to the main menu.
+To support usage of Emacs bookmarks@comma{} the following menu is added to the main menu.
 
 @image{images/anju-main-menu-bookmarks,,,,png}
 
@@ -354,7 +364,7 @@ An opinionated re-organization of the Help menu is provided.
 
 @image{images/anju-main-menu-help,,,,png}
 
-Anju provides support for customizing the enhancements (@ref{Main Menu Customization})
+Anju provides support for customizing the enhancements (@ref{Main Menu Customization, , Main Menu Customization})
  to the main menu.
 
 @node Window Management
@@ -367,7 +377,7 @@ Window management via mouse interaction is provided for through the @ref{Mode Li
 
 @cindex Requirements
 
-Anju requires Emacs 29.1+, Magit 4.4+, Casual 2.13+, Markdown Mode 2.7+.
+Anju requires Emacs 29.1+@comma{} Casual 2.13+@comma{} Markdown Mode 2.7+.
 
 Certain menus require more installed software:
 
@@ -377,6 +387,8 @@ Anju Dired Support: GNU Coreutils (@code{ls})
 @item
 Markdown import to Org: pandoc
 @end itemize
+
+Anju provides optional support for Magit 4.4+.
 
 @node Install
 @chapter Install
@@ -405,9 +417,9 @@ Call @code{anju-init} in your Emacs initialization file.
 @end lisp
 @end enumerate
 
-Anju supports a high degree of customization. Users who wish this should make a deep read of the @ref{Customization} section.
+Anju supports a high degree of customization. Users who wish this should make a deep read of the @ref{Customization, , Customization} section.
 
-While not required, the following additions to your Emacs initialization file can further enhance your mouse experience:
+While not required@comma{} the following additions to your Emacs initialization file can further enhance your mouse experience:
 
 @itemize
 @item
@@ -420,7 +432,7 @@ Enable @code{org-mouse}
 Add Markdown export support to Org mode
 @itemize
 @item
-@code{M-x} @code{customize-variable} @code{org-export-backends}, check @code{md} option.
+@code{M-x} @code{customize-variable} @code{org-export-backends}@comma{} check @code{md} option.
 @end itemize
 
 @item
@@ -431,7 +443,7 @@ Globally bind @code{C-x 1} to @code{anju-toggle-one-window}.
 @end lisp
 
 @item
-Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog interactions, or @code{nil} to always get a mini-buffer prompt.
+Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog interactions@comma{} or @code{nil} to always get a mini-buffer prompt.
 @end itemize
 
 @node Customization
@@ -439,7 +451,7 @@ Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog inter
 
 @cindex Customization
 
-Anju provides a number of ways to customize mouse interactions in Emacs. In many cases, Anju leverages off existing Emacs customization options, particularly around defining and modifying menus. Users who wish to modify menus in Emacs should familiarize themselves with menu keymaps (@ref{Menu Keymaps,elisp#Menu Keymaps,,elisp,}) and the Easy Menu (@ref{Easy Menu,elisp#Easy Menu,,elisp,}) library.
+Anju provides a number of ways to customize mouse interactions in Emacs. In many cases@comma{} Anju leverages off existing Emacs customization options@comma{} particularly around defining and modifying menus. Users who wish to modify menus in Emacs should familiarize themselves with menu keymaps (@ref{Menu Keymaps,elisp#Menu Keymaps,,elisp,}) and the Easy Menu (@ref{Easy Menu,elisp#Easy Menu,,elisp,}) library.
 
 Customization options for the different areas Anju covers are detailed below.
 
@@ -481,10 +493,10 @@ Reconfigure the main menu.
 
 The variable  @code{anju-reconfigure-main-menu-hook} is a list of functions which each modify a different section of the main menu.
 
-If @code{anju-reconfigure-main-menu-enable} is @code{t}, the variable @code{anju-help-menu-remove-emacs-tutorial} can control if the menu entries for the Emacs tutorial are shown.
+If @code{anju-reconfigure-main-menu-enable} is @code{t}@comma{} the variable @code{anju-help-menu-remove-emacs-tutorial} can control if the menu entries for the Emacs tutorial are shown.
 @end table
 
-By default, all the above @code{*-enable} variables are turned on (@code{t}).  Users preferring to make granular changes to @code{anju-init} can invoke @code{M-x} @code{customize-group} @code{anju}.
+By default@comma{} all the above @code{*-enable} variables are turned on (@code{t}).  Users preferring to make granular changes to @code{anju-init} can invoke @code{M-x} @code{customize-group} @code{anju}.
 
 @node Context Menu Customization
 @section Context Menu Customization
@@ -505,7 +517,7 @@ Anju uses @code{context-menu-mode} (introduced in Emacs 28) to define its contex
 @code{click} : a mouse event
 @end itemize
 
-When the context menu is raised, typically via right-click (@code{mouse-3}), each function in @code{context-menu-functions} is run, populating the context menu.
+When the context menu is raised@comma{} typically via right-click (@code{mouse-3})@comma{} each function in @code{context-menu-functions} is run@comma{} populating the context menu.
 
 The following example Elisp illustrates an implementation of a context menu function.
 
@@ -539,7 +551,7 @@ At the time of menu item definition
 At a higher level.
 @end enumerate
 
-The @emph{context} is determined by a predicate which can take into account different things, among them:
+The @emph{context} is determined by a predicate which can take into account different things@comma{} among them:
 
 @itemize
 @item
@@ -552,7 +564,7 @@ Cursor (Point) position
 Mouse position
 @end itemize
 
-In the example above, the context predicate is @code{(derived-mode-p 'text-mode)}.  Note that it is defined at a higher level to avoid instantiating menu items if the context does not apply.
+In the example above@comma{} the context predicate is @code{(derived-mode-p 'text-mode)}.  Note that it is defined at a higher level to avoid instantiating menu items if the context does not apply.
 
 The context predicate can be embedded in the menu item definition itself. See more about this with the @code{:visible} and @code{:active} keywords for the macro @code{easy-menu-define}.
 
@@ -570,6 +582,63 @@ Users can insert their own custom function.
 @item
 Top-down ordering of functions will similarly determine the order of menu items in the context menu.
 @end enumerate
+
+@menu
+* Anju Context Menu Functions::
+@end menu
+
+@node Anju Context Menu Functions
+@subsection Anju Context Menu Functions
+
+@vindex anju-context-menu-dired
+@vindex anju-context-menu-org-mode
+@vindex anju-context-menu-scratch
+@vindex anju-context-menu-buffers
+@vindex anju-context-menu-region
+@vindex anju-context-menu-narrow
+@vindex anju-context-menu-open-in
+@vindex anju-context-menu-vc
+@vindex anju-context-menu-markup
+@vindex anju-context-menu-wordcount
+@vindex anju-context-menu-window
+
+Anju provides the following context menu functions for convenience. They can be used as-is or serve as a base for user-customized behavior.
+
+@table @asis
+@item @code{anju-context-menu-dired}
+Dired commands.
+
+@item @code{anju-context-menu-org-mode} 
+Org mode commands.
+
+@item @code{anju-context-menu-scratch} 
+Open scratch buffer.
+
+@item @code{anju-context-menu-buffers}
+Buffer navigation commands.
+
+@item @code{anju-context-menu-region}
+Commands for selected text.
+
+@item @code{anju-context-menu-narrow}
+Narrow-related commands.
+
+@item @code{anju-context-menu-open-in}
+Open in Dired.
+
+@item @code{anju-context-menu-vc}
+Version control related commands.
+If Magit 4.4+ is installed@comma{} then calls to it are made from here.
+
+@item @code{anju-context-menu-markup}
+Commands to show/hide text markup (e.g. Org@comma{} Markdown).
+
+@item @code{anju-context-menu-wordcount}
+Word count command.
+
+@item @code{anju-context-menu-window}
+Window management commands.
+@end table
 
 @node Mode Line Buffer List Menu Customization
 @section Mode Line Buffer List Menu Customization
@@ -592,10 +661,10 @@ The pop-up buffer list menu can be customized two ways:
 
 @enumerate
 @item
-Customizing the variable @code{anju-buffer-list-filter-functions}, a list of filter functions that are run each time the pop-up menu is raised when left-clicking the mode line buffer name.
+Customizing the variable @code{anju-buffer-list-filter-functions}@comma{} a list of filter functions that are run each time the pop-up menu is raised when left-clicking the mode line buffer name.
 
 @item
-Customizing the variable @code{anju-mode-line-buffer-list-function}, which gives a user complete control on what is displayed in the pop-up menu.
+Customizing the variable @code{anju-mode-line-buffer-list-function}@comma{} which gives a user complete control on what is displayed in the pop-up menu.
 @end enumerate
 
 
@@ -603,7 +672,7 @@ Customizing the variable @code{anju-mode-line-buffer-list-function}, which gives
 
 This variable is an alist used by the function @code{anju-buffer-list-menu-items} to populate the list of buffers used in the pop up menu @code{anju-popup-buffer-menu}.
 
-This alist is filled using the following key, value pair types:
+This alist is filled using the following key@comma{} value pair types:
 
 @table @asis
 @item key
@@ -662,7 +731,7 @@ Users who wish define their own menu should override this value with their own f
 
 Anju modifies the main menu via the customizable hook variable @code{anju-reconfigure-main-menu-hook}. This hook is run in the command @code{anju-init}.
 
-By default, the following hook functions are run:
+By default@comma{} the following hook functions are run:
 
 @table @asis
 @item @code{anju-main-menu--reconfigure-text-mode}
@@ -708,7 +777,7 @@ Support for more built-in modes
 Further changes to the main menu
 @end itemize
 
-Although much consideration on both the user and developer experience has been made, they are both subject to change in future releases if a better approach presents itself.
+Although much consideration on both the user and developer experience has been made@comma{} they are both subject to change in future releases if a better approach presents itself.
 
 @node Feedback & Discussion
 @chapter Feedback & Discussion
@@ -717,14 +786,14 @@ Although much consideration on both the user and developer experience has been m
 Please report any feedback about Anju to the @uref{https://github.com/kickingvegas/anju/issues, issue tracker on GitHub}.
 
 @cindex Discussion
-To participate in general discussion about using Anju, please join the @uref{https://github.com/kickingvegas/anju/discussions, discussion group}.
+To participate in general discussion about using Anju@comma{} please join the @uref{https://github.com/kickingvegas/anju/discussions, discussion group}.
 
 @node Sponsorship
 @chapter Sponsorship
 
 @cindex Sponsorship
 
-It costs money to make, enhance, and maintain Anju as ideologically free software. If you enjoy using Anju, please buy me a coffee to help support its development and maintenance.
+It costs money to make@comma{} enhance@comma{} and maintain Anju as ideologically free software. If you enjoy using Anju@comma{} please buy me a coffee to help support its development and maintenance.
 
 @image{images/default-yellow,,,,png}
 
@@ -735,7 +804,7 @@ It costs money to make, enhance, and maintain Anju as ideologically free softwar
 
 @cindex About Anju
 
-@uref{https://github.com/kickingvegas/anju, Anju} was conceived and crafted by Charles Choi in San Francisco, California.
+@uref{https://github.com/kickingvegas/anju, Anju} was conceived and crafted by Charles Choi in San Francisco@comma{} California.
 
 Thank you for using Anju.
 
@@ -746,7 +815,7 @@ Always choose love.
 
 @cindex Acknowledgments
 
-Thanks goes out to the contributors to @code{mouse.el}, whose work this package builds upon.
+Thanks goes out to the contributors to @code{mouse.el}@comma{} whose work this package builds upon.
 
 @node Main Index
 @chapter Main Index
@@ -758,7 +827,7 @@ Index for this user guide.
 @node Variable Index
 @chapter Variable Index
 
-Variables, functions, commands, and menus referenced by this user guide.
+Variables@comma{} functions@comma{} commands@comma{} and menus referenced by this user guide.
 
 @printindex vr
 

--- a/lisp/Makefile-anju.make
+++ b/lisp/Makefile-anju.make
@@ -19,13 +19,13 @@ include Makefile--defines.make
 PACKAGE_NAME=anju
 CASUAL_LIB_DIR=$(ANJU_BASE_DIR)/../casual/lisp
 
-ELISP_INCLUDES= \
-anju-utils.el \
+ELISP_INCLUDES=					\
+anju-utils.el					\
 anju-style-text.el
 
-ELISP_PACKAGES= \
-anju-context-menu.el \
-anju-main-menu.el \
+ELISP_PACKAGES=					\
+anju-context-menu.el				\
+anju-main-menu.el				\
 anju-mode-line.el
 
 ELISP_TEST_INCLUDES=anju-test-utils.el
@@ -36,6 +36,10 @@ PACKAGE_PATHS=					\
 -L $(EMACS_ELPA_DIR)/transient-current		\
 -L $(EMACS_ELPA_DIR)/cond-let-current		\
 -L $(EMACS_ELPA_DIR)/markdown-mode-current	\
+-L $(EMACS_ELPA_DIR)/magit-current		\
+-L $(EMACS_ELPA_DIR)/magit-section-current	\
+-L $(EMACS_ELPA_DIR)/llama-current		\
+-L $(EMACS_ELPA_DIR)/with-editor-current	\
 -L $(CASUAL_LIB_DIR)				\
 -L $(ANJU_LISP_DIR)
 

--- a/lisp/anju-context-menu.el
+++ b/lisp/anju-context-menu.el
@@ -198,60 +198,69 @@ and convert it to Org using the pandoc utility."
 
 This function is intended to be hooked into `context-menu-functions'."
 
-  (save-excursion
-    (when (mouse-posn-property (event-start click) 'dired-filename)
-      (easy-menu-add-item menu nil
-                          ["Rename to…"
-                           dired-do-rename
-                           :help "Rename or move file"])
+  (when (derived-mode-p 'dired-mode)
+    (save-excursion
+      (when (mouse-posn-property (event-start click) 'dired-filename)
+        (easy-menu-add-item menu nil
+                            ["Rename to…"
+                             dired-do-rename
+                             :help "Rename or move file"])
 
-      (easy-menu-add-item menu nil
-                          ["Copy to…"
-                           dired-do-copy
-                           :help "Copy file"])
+        (easy-menu-add-item menu nil
+                            ["Copy to…"
+                             dired-do-copy
+                             :help "Copy file"])
 
-      (easy-menu-add-item menu nil
-                          ["Symlink…"
-                           dired-do-relsymlink
-                           :help "Make relative symlink"])
+        (easy-menu-add-item menu nil
+                            ["Symlink…"
+                             dired-do-relsymlink
+                             :help "Make relative symlink"])
 
-      (easy-menu-add-item
-       menu
-       nil
-       ["Duplicate"
-        anju-dired-duplicate-file
-        :label (format "Duplicate “%s”"
-                       (anju-filename-from-path (dired-get-filename)))
+        (easy-menu-add-item menu nil
+                            ["Toggle Thumbnail"
+                             image-dired-dired-toggle-marked-thumbs
+                             :visible (string-match-p (image-file-name-regexp)
+                                                      (dired-get-filename))
+                             :help "Toggle thumbnails in front of marked \
+file names in the Dired buffer."])
 
-        :help "Duplicate selected item"])
+        (easy-menu-add-item
+         menu
+         nil
+         ["Duplicate"
+          anju-dired-duplicate-file
+          :label (format "Duplicate “%s”"
+                         (anju-filename-from-path (dired-get-filename)))
 
-      ;; (easy-menu-add-item menu nil
-      ;;                     ["Change Mode…"
-      ;;                      dired-do-chmod
-      ;;                      :help "Change mode of file (chmod)"])
+          :help "Duplicate selected item"])
 
-      (easy-menu-add-item menu nil
-                          ["Insert Subdir"
-                           dired-maybe-insert-subdir
-                           :label (format "Insert “%s” View"
-                                          (anju-filename-from-path (dired-get-filename)))
-                           :visible (file-directory-p
-                                     (dired-file-name-at-point))
-                           :help "Insert subdir (sub-directory)"])
+        ;; (easy-menu-add-item menu nil
+        ;;                     ["Change Mode…"
+        ;;                      dired-do-chmod
+        ;;                      :help "Change mode of file (chmod)"])
 
-      (anju-context-menu-item-separator menu trash-separator)
+        (easy-menu-add-item menu nil
+                            ["Insert Subdir"
+                             dired-maybe-insert-subdir
+                             :label (format "Insert “%s” View"
+                                            (anju-filename-from-path (dired-get-filename)))
+                             :visible (file-directory-p
+                                       (dired-file-name-at-point))
+                             :help "Insert subdir (sub-directory)"])
 
-      (easy-menu-add-item menu nil
-                          ["Move to Trash…"
-                           dired-do-delete
-                           :visible (file-writable-p
-                                     (dired-file-name-at-point))
-                           :help "Delete all marked files."])
+        (anju-context-menu-item-separator menu trash-separator)
 
-      (anju-context-menu-item-separator menu dired-separator))
+        (easy-menu-add-item menu nil
+                            ["Move to Trash…"
+                             dired-do-delete
+                             :visible (file-writable-p
+                                       (dired-file-name-at-point))
+                             :help "Delete all marked files."])
 
-    (mouse-set-point click)
-    (when (derived-mode-p 'dired-mode)
+        (anju-context-menu-item-separator menu dired-separator))
+
+      (mouse-set-point click)
+
       (easy-menu-add-item menu nil
                           ["Toggle Subdir View"
                            dired-hide-subdir
@@ -300,9 +309,9 @@ This function is intended to be hooked into `context-menu-functions'."
                            :help "Hide directory details"])
 
       (easy-menu-add-item menu nil
-                        ["📁 Dired…"
-                         dired
-                         :help "Open Dired"])))
+                          ["📁 Dired…"
+                           dired
+                           :help "Open Dired"])))
   menu)
 
 
@@ -540,17 +549,19 @@ This function is intended to be hooked into `context-menu-functions'."
 
       (anju-context-menu-item-separator menu vc-separator)
 
-      (if (buffer-file-name)
+      (when (package-installed-p 'magit)
+        (require 'magit)
+        (if (buffer-file-name)
+            (easy-menu-add-item
+             menu nil
+             ["Magit Dispatch…"
+              magit-file-dispatch
+              :help "Show the status of the current Git repository in a buffer"])
           (easy-menu-add-item
            menu nil
-           ["Magit Dispatch…"
-            magit-file-dispatch
-            :help "Show the status of the current Git repository in a buffer"])
-        (easy-menu-add-item
-         menu nil
-         ["Magit Status"
-          magit-status
-          :help "Show the status of the current Git repository in a buffer"]))
+           ["Magit Status"
+            magit-status
+            :help "Show the status of the current Git repository in a buffer"])))
 
       (easy-menu-add-item
        menu nil

--- a/lisp/anju.el
+++ b/lisp/anju.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/kickingvegas/anju
 ;; Keywords: tools
 ;; Version: 1.0.6-rc.1
-;; Package-Requires: ((emacs "29.1") (magit "4.4.0") (casual "2.14.0") (markdown-mode "2.7"))
+;; Package-Requires: ((emacs "29.1") (casual "2.14.0") (markdown-mode "2.7"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/tests/test-anju-context-menu.el
+++ b/tests/test-anju-context-menu.el
@@ -23,6 +23,7 @@
 ;;
 
 ;;; Code:
+(require 'cl-lib)
 (require 'anju-context-menu)
 (require 'anju-test-utils)
 
@@ -175,66 +176,58 @@
   (anju-test-context-menu-function
    #'anju-context-menu-dired
    "hi there"
-   14
+   15
    (lambda (items)
-     (let* ((item0 (seq-elt items 0))
-            (item1 (seq-elt items 1))
-            (item2 (seq-elt items 2))
-            (item3 (seq-elt items 3))
-            (item4 (seq-elt items 4))
-            (item5 (seq-elt items 5))
-            (item6 (seq-elt items 6))
-            (item7 (seq-elt items 7))
-            (item8 (seq-elt items 8))
-            (item9 (seq-elt items 9))
-            (item10 (seq-elt items 10))
-            (item11 (seq-elt items 11))
-            (item12 (seq-elt items 12))
-            (item13 (seq-elt items 13)))
-
+     (let ((i 0))
        (anju-test-menu-item
-        item0
+        (seq-elt items i)
         "Rename to…"
         #'dired-do-rename
         "Rename or move file")
 
        (anju-test-menu-item
-        item1
+        (seq-elt items (cl-incf i))
         "Copy to…"
         #'dired-do-copy
         "Copy file")
 
        (anju-test-menu-item
-        item2
+        (seq-elt items (cl-incf i))
         "Symlink…"
         #'dired-do-relsymlink
         "Make relative symlink")
 
        (anju-test-menu-item
-        item3
+        (seq-elt items (cl-incf i))
+        "Toggle Thumbnail"
+        #'image-dired-dired-toggle-marked-thumbs
+        "Toggle thumbnails in front of marked file names in the Dired buffer.")
+
+       (anju-test-menu-item
+        (seq-elt items (cl-incf i))
         (lambda () (format "Duplicate “%s”" (anju-filename-from-path (dired-get-filename))))
         #'anju-dired-duplicate-file
         "Duplicate selected item")
 
        (anju-test-menu-item
-        item4
+        (seq-elt items (cl-incf i))
         (lambda () (format "Insert “%s” View"
                       (anju-filename-from-path (dired-get-filename))))
         #'dired-maybe-insert-subdir
         "Insert subdir (sub-directory)")
 
-       (anju-test-menu-item item5 "--")
+       (anju-test-menu-item (seq-elt items (cl-incf i)) "--")
 
        (anju-test-menu-item
-        item6
+        (seq-elt items (cl-incf i))
         "Move to Trash…"
         #'dired-do-delete
         "Delete all marked files.")
 
-       (anju-test-menu-item item7 "--")
+       (anju-test-menu-item (seq-elt items (cl-incf i)) "--")
 
        (anju-test-menu-item
-        item8
+        (seq-elt items (cl-incf i))
         (lambda () (format
                "%s “%s” View"
                (if (dired-subdir-hidden-p
@@ -247,7 +240,7 @@
         "Toggle hide subdir (sub-directory)")
 
        (anju-test-menu-item
-        item9
+        (seq-elt items (cl-incf i))
         (lambda () (format
                "Remove “%s” View"
                (anju-filename-from-path
@@ -256,27 +249,25 @@
         #'dired-kill-subdir
         "Kill subdir (sub-directory)")
 
-       (should (string-equal (seq-elt item10 2) "Sort By"))
+       (should (string-equal (seq-elt (seq-elt items (cl-incf i)) 2) "Sort By"))
 
        (anju-test-menu-item
-        item11
+        (seq-elt items (cl-incf i))
         "Omit Mode"
         #'dired-omit-mode
         "Omit mode")
 
        (anju-test-menu-item
-        item12
+        (seq-elt items (cl-incf i))
         "Hide Details"
         #'dired-hide-details-mode
         "Hide directory details")
 
        (anju-test-menu-item
-        item13
+        (seq-elt items (cl-incf i))
         "📁 Dired…"
         #'dired
-        "Open Dired")
-
-       )))
+        "Open Dired"))))
   (kill-buffer))
 
 (ert-deftest test-anju-context-menu-scratch ()
@@ -532,19 +523,16 @@
    "hi there"
    3
    (lambda (items)
-     (let* ((item0 (seq-elt items 0))
-            (item1 (seq-elt items 1))
-            (item2 (seq-elt items 2)))
-       (anju-test-menu-item item0 "--")
-
+     (let ((i 0))
+       (anju-test-menu-item (seq-elt items i) "--")
        (anju-test-menu-item
-        item1
+        (seq-elt items (cl-incf i))
         "Magit Dispatch…"
         #'magit-file-dispatch
         "Show the status of the current Git repository in a buffer")
 
        (anju-test-menu-item
-        item2
+        (seq-elt items (cl-incf i))
         "Ediff revision…"
         #'casual-ediff-revision-from-menu
         "Ediff this file with revision"))))


### PR DESCRIPTION
* lisp/anju-context-menu.el
(anju-context-menu-vc): Test if Magit is installed before instantiating calls to Magit.
(anju-context-menu-dired): Add support to toggle image thumbnail.

* Fix unit tests

* Update documentation:
  - Requirements
  - Anju context menu functions
  - Magit support
