### PR TITLE
Add index menu (imenu) to main menu

### DIFF
--- a/docs/anju.org
+++ b/docs/anju.org
@@ -268,14 +268,25 @@ To support usage of Emacs bookmarks, the following menu is added to the main men
 
 [[file:images/anju-main-menu-bookmarks.png]]
 
-#+TEXINFO: @subheading Re-organization of the Help menu
+
+#+TEXINFO: @subheading Index menu (imenu)
+
+Anju adds the index menu ([[info:emacs#Imenu][emacs#Imenu]]) to the main menu bar for modes that support it. Anju will configure the following modes with ~imenu-add-menubar-index~:
+
+- ~prog-mode~ derived modes
+- ~makefile-mode~
+- ~org-mode~
+- ~markdown-mode~
+
+
+
+#+TEXINFO: @subheading Help menu
 
 An opinionated re-organization of the Help menu is provided.
 
 [[file:images/anju-main-menu-help.png]]
 
-Anju provides support for customizing the enhancements ([[#main-menu-customization][Main Menu Customization]])
- to the main menu.
+Anju provides support for customizing all the above enhancements to the main menu. See [[#main-menu-customization][Main Menu Customization]] for more detail.
 
 ** Window Management
 #+CINDEX: Window Management
@@ -367,13 +378,15 @@ Anju has a number of customizable variables that determine the behavior of ~anju
 
 - ~anju-unset-legacy-mouse-bindings-enable~ :: Remove bindings using ~mouse-2~.
 
-- ~anju-reconfigure-main-menu-enable~ :: Reconfigure the main menu.
+- ~anju-reconfigure-main-menu-enable~ :: Top-level variable to reconfigure the main menu.
 
-  The variable  ~anju-reconfigure-main-menu-hook~ is a list of functions which each modify a different section of the main menu.
+  If ~anju-reconfigure-main-menu-enable~ is ~t~, the following variables determine how the main menu is reconfigured:
 
-  If ~anju-reconfigure-main-menu-enable~ is ~t~, the variable ~anju-help-menu-remove-emacs-tutorial~ can control if the menu entries for the Emacs tutorial are shown.
+  - ~anju-reconfigure-main-menu-hook~ :: a list of functions, each modifying a sub-menu of the main menu.
 
-By default, all the above ~*-enable~ variables are turned on (~t~).  Users preferring to make granular changes to ~anju-init~ can invoke ~M-x~ ~customize-group~ ~anju~.
+  - ~anju-help-menu-remove-emacs-tutorial~ :: control if the Emacs tutorial menu items are shown.
+
+By default, all the above ~*-enable~ variables are set to ~t~.  Users preferring to make granular changes to ~anju-init~ can invoke ~M-x~ ~customize-group~ ~anju~.
 
 
 ** Context Menu Customization
@@ -553,6 +566,7 @@ Users who wish define their own menu should override this value with their own f
 #+VINDEX: anju-main-menu--reconfigure-text-mode
 #+VINDEX: anju-main-menu--reconfigure-bookmarks
 #+VINDEX: anju-main-menu--reconfigure-help
+#+VINDEX: anju-main-menu--reconfigure-imenu
 #+VINDEX: anju-help-menu-remove-emacs-tutorial
 
 Anju modifies the main menu via the customizable hook variable ~anju-reconfigure-main-menu-hook~. This hook is run in the command ~anju-init~.
@@ -560,9 +574,19 @@ Anju modifies the main menu via the customizable hook variable ~anju-reconfigure
 By default, the following hook functions are run:
 
 - ~anju-main-menu--reconfigure-text-mode~ :: Reconfigures Text menu for text mode buffers.
+
 - ~anju-main-menu--reconfigure-bookmarks~ :: Adds Bookmarks menu to main menu.
+
 - ~anju-main-menu--reconfigure-help~ :: Reconfigures Help menu.
   - Set the customizable variable ~anju-help-menu-remove-emacs-tutorial~ to ~t~ if removing the tutorial entries is desired.
+
+- ~anju-main-menu--reconfigure-imenu~ :: Adds an index menu (imenu) to the following modes:
+  - ~prog-mode~
+  - ~makefile-mode~
+  - ~org-mode~
+  - ~markdown-mode~
+
+Execution of any of the above functions can be set to preference in ~anju-reconfigure-main-menu-hook~.    
 
 ~anju-reconfigure-main-menu-hook~ can be modified to add additional custom hook functions. Users who wish to do this should familiarize themselves with menu keymaps ([[info:elisp#Menu Keymaps][elisp#Menu Keymaps]]) and the Easy Menu ([[info:elisp#Easy Menu][elisp#Easy Menu]]) library.
 

--- a/docs/anju.texi
+++ b/docs/anju.texi
@@ -50,11 +50,11 @@ Support direct manipulation when possible
 Re-organization of the main menu bar
 @end itemize
 
-The features offered by Anju are opinionated@comma{} but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
+The features offered by Anju are opinionated, but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
 
 Please note that all UI terminology in this document is Emacs-centric and differs from conventional GUI terminology. Refer to (emacs) Frames (@ref{Frames,emacs#Frames,,emacs,}) for more detail on this.
 
-It costs money to make@comma{} enhance@comma{} and maintain Anju as ideologically free software. If you enjoy using Anju@comma{} please buy me a coffee to help support its development and maintenance.
+It costs money to make, enhance, and maintain Anju as ideologically free software. If you enjoy using Anju, please buy me a coffee to help support its development and maintenance.
 
 @image{images/default-yellow,,,,png}
 
@@ -135,7 +135,7 @@ Lengthy menus that feel more like an inventory of commands rather than a designe
 Over-reliance on mouse workflows that require switching between the mouse and keyboard.
 @end itemize
 
-Anju makes opinionated design decisions@comma{} but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
+Anju makes opinionated design decisions, but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
 
 Elaboration on what informs Anju's opinions is described below.
 
@@ -150,7 +150,7 @@ Elaboration on what informs Anju's opinions is described below.
 
 This section conveys the principles and concerns used by Anju to inform its design decisions.
 
-Editorially@comma{} all design decisions for Anju are ultimately the opinion of Charles Y@. Choi.
+Editorially, all design decisions for Anju are ultimately the opinion of Charles Y@. Choi.
 
 
 @subheading General Principles
@@ -165,18 +165,18 @@ A coherent information architecture should be conveyed.
 Balance between concision and discoverability should be made in a menu's offerings.
 @end itemize
 @item
-Nesting of sub-menus should be carefully considered@comma{} ideally not exceeding a depth of two.
+Nesting of sub-menus should be carefully considered, ideally not exceeding a depth of two.
 @item
 Mouse workflows that require keyboard input should be minimized.
 @item
-If the opportunity to provide a direct manipulation experience is available@comma{} it should be taken.
+If the opportunity to provide a direct manipulation experience is available, it should be taken.
 @item
 Unconventional mouse interactions should be avoided.
 @end itemize
 
 @subheading Concerns
 
-Anju takes the position that different types of menus have different concerns or objectives. This is most apparent in contrasting the design of a main menu section (e.g. File@comma{} Edit@comma{} Options@comma{} …) to that of a context menu.
+Anju takes the position that different types of menus have different concerns or objectives. This is most apparent in contrasting the design of a main menu section (e.g. File, Edit, Options, …) to that of a context menu.
 
 For Anju:
 
@@ -187,7 +187,7 @@ The highest concern of a main menu section is discoverability.
 The highest concern of a context menu is concision.
 @end itemize
 
-A common implementation practice in Emacs is to reuse menu keymaps for both the main menu and context menus. This violates the above concerns@comma{} which Anju seeks to address.
+A common implementation practice in Emacs is to reuse menu keymaps for both the main menu and context menus. This violates the above concerns, which Anju seeks to address.
 
 The next sub-sections further detail the design concerns with respect to an area where mouse interaction occurs.
 
@@ -212,11 +212,11 @@ Anju takes the opinion that context menus should @emph{not} support general comm
 
 @subsubheading Direct Manipulation
 
-Support for direct action based on mouse cursor position is a common user interaction technique. Anju applies this to Emacs window management@comma{} where window creation@comma{} deletion@comma{} and swapping are supported from both the context menu and the mode line.
+Support for direct action based on mouse cursor position is a common user interaction technique. Anju applies this to Emacs window management, where window creation, deletion, and swapping are supported from both the context menu and the mode line.
 
 @subsubheading No Middle Button Bindings
 
-Anju eschews Emacs' default middle mouse button bindings as they presume usage of a @uref{https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Sun_optical_mouse.jpg/960px-Sun_optical_mouse.jpg, 90's style 3-button mouse}. This style of mouse design has long been superseded with a middle @uref{https://upload.wikimedia.org/wikipedia/commons/2/22/3-Tasten-Maus_Microsoft.jpg, scroll-wheel+button control}. This widespread hardware change has resulted in the majority of mouse-supporting applications to emphasize scrolling actions with the middle control and clicking actions to the left and right buttons. Anju follows suit@comma{} primarily binding the right mouse button click (down) event to raising a context menu. In addition@comma{} Anju reconfigures commands that were previously bound to the middle button to ones accessible via a context menu.
+Anju eschews Emacs' default middle mouse button bindings as they presume usage of a @uref{https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Sun_optical_mouse.jpg/960px-Sun_optical_mouse.jpg, 90's style 3-button mouse}. This style of mouse design has long been superseded with a middle @uref{https://upload.wikimedia.org/wikipedia/commons/2/22/3-Tasten-Maus_Microsoft.jpg, scroll-wheel+button control}. This widespread hardware change has resulted in the majority of mouse-supporting applications to emphasize scrolling actions with the middle control and clicking actions to the left and right buttons. Anju follows suit, primarily binding the right mouse button click (down) event to raising a context menu. In addition, Anju reconfigures commands that were previously bound to the middle button to ones accessible via a context menu.
 
 The only exception Anju makes in this matter is to keep the Emacs default binding of @code{mouse-2} to @code{mouse-yank-primary}.
 
@@ -244,7 +244,7 @@ The following mode line enhancements are provided by Anju:
 @subheading Pop-up Buffer List
 @cindex Pop-up Buffer List
 
-On the mode line@comma{} left-click (@code{mouse-1}) on the buffer name to raise a pop-up menu containing a list of open buffers. The contents of this list is controlled by the customizable variable @code{anju-buffer-list-filter-functions}. More info on customizing the buffer list menu can be found in @ref{Mode Line Buffer List Menu Customization, , Mode Line Buffer List Menu Customization}.
+On the mode line, left-click (@code{mouse-1}) on the buffer name to raise a pop-up menu containing a list of open buffers. The contents of this list is controlled by the customizable variable @code{anju-buffer-list-filter-functions}. More info on customizing the buffer list menu can be found in @ref{Mode Line Buffer List Menu Customization}.
 
 
 @image{images/anju-mode-line-buffer-list,,,,png}
@@ -256,7 +256,7 @@ A right-click (@code{mouse-3}) on any blank space on the mode line will pop-up a
 
 @image{images/anju-mode-line-window-management,,,,png}
 
-From here@comma{} one can:
+From here, one can:
 @itemize
 @item
 Delete the window (×)
@@ -265,7 +265,7 @@ Split the window horizontally (→)
 @item
 Split the window vertically (↓)
 @item
-If multiple windows are shown@comma{} swap the current window.
+If multiple windows are shown, swap the current window.
 @end itemize
 
 Note: usage of ``window'' refers to the Emacs definition of it. Refer to @ref{Frames,emacs#Frames,,emacs,} for more detail on this.
@@ -273,7 +273,7 @@ Note: usage of ``window'' refers to the Emacs definition of it. Refer to @ref{Fr
 @subheading Toggle Maximize Window
 @cindex Toggle Maximize Window
 
-A left-double-click on any blank space on the mode line will checkpoint the current window configuration@comma{} then maximize the current window (@code{delete-other-windows}). Re-doing the left-double-click will restore the prior window configuration.
+A left-double-click on any blank space on the mode line will checkpoint the current window configuration, then maximize the current window (@code{delete-other-windows}). Re-doing the left-double-click will restore the prior window configuration.
 
 @node Context Menu
 @section Context Menu
@@ -296,10 +296,10 @@ Dired
 @item
 Window management
 @item
-Full support for @code{context-menu-mode} customization (See @ref{Context Menu Customization, , Context Menu Customization}).
+Full support for @code{context-menu-mode} customization (See @ref{Context Menu Customization}).
 @end itemize
 
-Anju deliberately omits the display of the default mode-specific menu keymaps in the context menu as they are considered redundant to their display in the main menu. Rationale for this is described in @ref{Design Principles and Concerns, , Design Principles and Concerns}. Users can still access the default mode-specific menu keymap by using the binding @kbd{C-<mouse-3>}.
+Anju deliberately omits the display of the default mode-specific menu keymaps in the context menu as they are considered redundant to their display in the main menu. Rationale for this is described in @ref{Design Principles and Concerns}. Users can still access the default mode-specific menu keymap by using the binding @kbd{C-<mouse-3>}.
 
 
 
@@ -319,18 +319,18 @@ Learn more about the different areas Anju enhances context menus in the links be
 
 @image{images/anju-context-menu-region,,,,png}
 
-If a context menu is raised on selected text@comma{} the following menu items are displayed:
+If a context menu is raised on selected text, the following menu items are displayed:
 
 @table @asis
 @item Style
-Applies mode-specific markup to emphasize the selected text (e.g. bold@comma{} italic@comma{} code@comma{} etc.).
+Applies mode-specific markup to emphasize the selected text (e.g. bold, italic, code, etc.).
 @itemize
 @item
 Available only for @code{org-mode} and @code{markdown-mode}.
 @end itemize
 
 @item Transform Text
-Applies transforms (upper/lower case@comma{} capitalize) to the selected text.
+Applies transforms (upper/lower case, capitalize) to the selected text.
 
 @item Occur
 Run @code{occur} command to show occurrences of selected text.
@@ -362,9 +362,9 @@ Item
 Table
 @end itemize
 
-In addition if text is selected@comma{} then support for styling it is supported.
+In addition if text is selected, then support for styling it is supported.
 
-Note that the Org mode context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns, , Design Principles and Concerns}.
+Note that the Org mode context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns}.
 
 It is recommended that the @code{org-mouse} package be loaded when using
 
@@ -377,20 +377,20 @@ It is recommended that the @code{org-mouse} package be loaded when using
 @node Org Headline
 @subsubsection Org Headline
 
-If the context menu is raised on a headline@comma{} then commands related to clocking and promotion are offered.
+If the context menu is raised on a headline, then commands related to clocking and promotion are offered.
 
 @image{images/anju-context-menu-org-headline,,,,png}
 
 @node Org Item
 @subsubsection Org Item
 
-If the context menu is raised on a list item@comma{} then commands related to promotion and conversion to a checkbox are provided.
+If the context menu is raised on a list item, then commands related to promotion and conversion to a checkbox are provided.
 
-The menu item ``To Checkbox'' will convert an item to a checkbox@comma{} with the additional behavior that if the point is at the start of the whole list@comma{} the whole list will be turned into checkboxes.
+The menu item ``To Checkbox'' will convert an item to a checkbox, with the additional behavior that if the point is at the start of the whole list, the whole list will be turned into checkboxes.
 
 @image{images/anju-context-menu-org-item,,,,png}
 
-If @code{org-mouse} is loaded@comma{} then clicking on a checkbox will toggle its state between on ('[X]') or off ('[ ]'). However@comma{} changing to an intermediate state ('[-]') is supported by the menu item ``In-Progress''. The menu item ``To Item'' will convert the checkbox back to a plain list item.
+If @code{org-mouse} is loaded, then clicking on a checkbox will toggle its state between on ('[X]') or off ('[ ]'). However, changing to an intermediate state ('[-]') is supported by the menu item ``In-Progress''. The menu item ``To Item'' will convert the checkbox back to a plain list item.
 
 @image{images/anju-context-menu-org-checkbox,,,,png}
 
@@ -399,7 +399,7 @@ Note that checkboxes in screenshots are prettified using @code{prettify-symbols-
 @node Org Table
 @subsubsection Org Table
 
-If the context menu is raised in a table@comma{} then table-specific commands are shown.
+If the context menu is raised in a table, then table-specific commands are shown.
 
 @image{images/anju-context-menu-org-table,,,,png}
 
@@ -412,18 +412,18 @@ Anju has context menu support for Dired mode. The screenshot below shows the con
 
 @image{images/anju-dired-copy-to,,,,png}
 
-If the mouse point is over a directory@comma{} the option to insert a view (aka subdir) for it in the buffer is provided.
+If the mouse point is over a directory, the option to insert a view (aka subdir) for it in the buffer is provided.
 
 @image{images/anju-dired-insert-subdir,,,,png}
 
-Note that the Dired context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns, , Design Principles and Concerns}.
+Note that the Dired context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns}.
 
 @node Magit Support
 @subsection Magit Support
 
 @cindex Magit Support
 
-If Magit 4.4+ is installed@comma{} then the context menu function @code{anju-context-menu-vc} will offer Magit commands depending on context. If the context menu is raised in a file buffer@comma{} then the menu item ``Magit Dispatch…'' (@code{magit-file-dispatch}) is shown@comma{} otherwise ``Magit Status'' (@code{magit-status}).
+If Magit 4.4+ is installed, then the context menu function @code{anju-context-menu-vc} will offer Magit commands depending on context. If the context menu is raised in a file buffer, then the menu item ``Magit Dispatch…'' (@code{magit-file-dispatch}) is shown, otherwise ``Magit Status'' (@code{magit-status}).
 
 @node Main Menu
 @section Main Menu
@@ -434,18 +434,35 @@ Anju offers the following enhancements to the main menu:
 
 @subheading Bookmarks menu
 
-To support usage of Emacs bookmarks@comma{} the following menu is added to the main menu.
+To support usage of Emacs bookmarks, the following menu is added to the main menu.
 
 @image{images/anju-main-menu-bookmarks,,,,png}
 
-@subheading Re-organization of the Help menu
+
+@subheading Index menu (imenu)
+
+Anju adds the index menu (@ref{Imenu,emacs#Imenu,,emacs,}) to the main menu bar for modes that support it. Anju will configure the following modes with @code{imenu-add-menubar-index}:
+
+@itemize
+@item
+@code{prog-mode} derived modes
+@item
+@code{makefile-mode}
+@item
+@code{org-mode}
+@item
+@code{markdown-mode}
+@end itemize
+
+
+
+@subheading Help menu
 
 An opinionated re-organization of the Help menu is provided.
 
 @image{images/anju-main-menu-help,,,,png}
 
-Anju provides support for customizing the enhancements (@ref{Main Menu Customization, , Main Menu Customization})
- to the main menu.
+Anju provides support for customizing all the above enhancements to the main menu. See @ref{Main Menu Customization} for more detail.
 
 @node Window Management
 @section Window Management
@@ -459,7 +476,7 @@ Window management via mouse interaction is provided for through the @ref{Mode Li
 
 @cindex Requirements
 
-Anju requires Emacs 29.1+@comma{} Casual 2.13+@comma{} Markdown Mode 2.7+.
+Anju requires Emacs 29.1+, Casual 2.13+, Markdown Mode 2.7+.
 
 Certain menus require more installed software:
 
@@ -499,9 +516,9 @@ Call @code{anju-init} in your Emacs initialization file.
 @end lisp
 @end enumerate
 
-Anju supports a high degree of customization. Users who wish this should make a deep read of the @ref{Customization, , Customization} section.
+Anju supports a high degree of customization. Users who wish this should make a deep read of the @ref{Customization} section.
 
-While not required@comma{} the following additions to your Emacs initialization file can further enhance your mouse experience:
+While not required, the following additions to your Emacs initialization file can further enhance your mouse experience:
 
 @itemize
 @item
@@ -514,7 +531,7 @@ Enable @code{org-mouse}
 Add Markdown export support to Org mode
 @itemize
 @item
-@code{M-x} @code{customize-variable} @code{org-export-backends}@comma{} check @code{md} option.
+@code{M-x} @code{customize-variable} @code{org-export-backends}, check @code{md} option.
 @end itemize
 
 @item
@@ -525,7 +542,7 @@ Globally bind @code{C-x 1} to @code{anju-toggle-one-window}.
 @end lisp
 
 @item
-Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog interactions@comma{} or @code{nil} to always get a mini-buffer prompt.
+Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog interactions, or @code{nil} to always get a mini-buffer prompt.
 @end itemize
 
 @node Customization
@@ -533,7 +550,7 @@ Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog inter
 
 @cindex Customization
 
-Anju provides a number of ways to customize mouse interactions in Emacs. In many cases@comma{} Anju leverages off existing Emacs customization options@comma{} particularly around defining and modifying menus. Users who wish to modify menus in Emacs should familiarize themselves with menu keymaps (@ref{Menu Keymaps,elisp#Menu Keymaps,,elisp,}) and the Easy Menu (@ref{Easy Menu,elisp#Easy Menu,,elisp,}) library.
+Anju provides a number of ways to customize mouse interactions in Emacs. In many cases, Anju leverages off existing Emacs customization options, particularly around defining and modifying menus. Users who wish to modify menus in Emacs should familiarize themselves with menu keymaps (@ref{Menu Keymaps,elisp#Menu Keymaps,,elisp,}) and the Easy Menu (@ref{Easy Menu,elisp#Easy Menu,,elisp,}) library.
 
 Customization options for the different areas Anju covers are detailed below.
 
@@ -571,14 +588,20 @@ Enable Anju-defined bindings for the mode line.
 Remove bindings using @code{mouse-2}.
 
 @item @code{anju-reconfigure-main-menu-enable}
-Reconfigure the main menu.
+Top-level variable to reconfigure the main menu.
 
-The variable  @code{anju-reconfigure-main-menu-hook} is a list of functions which each modify a different section of the main menu.
+If @code{anju-reconfigure-main-menu-enable} is @code{t}, the following variables determine how the main menu is reconfigured:
 
-If @code{anju-reconfigure-main-menu-enable} is @code{t}@comma{} the variable @code{anju-help-menu-remove-emacs-tutorial} can control if the menu entries for the Emacs tutorial are shown.
+@table @asis
+@item @code{anju-reconfigure-main-menu-hook}
+a list of functions, each modifying a sub-menu of the main menu.
+
+@item @code{anju-help-menu-remove-emacs-tutorial}
+control if the Emacs tutorial menu items are shown.
+@end table
 @end table
 
-By default@comma{} all the above @code{*-enable} variables are turned on (@code{t}).  Users preferring to make granular changes to @code{anju-init} can invoke @code{M-x} @code{customize-group} @code{anju}.
+By default, all the above @code{*-enable} variables are set to @code{t}.  Users preferring to make granular changes to @code{anju-init} can invoke @code{M-x} @code{customize-group} @code{anju}.
 
 @node Context Menu Customization
 @section Context Menu Customization
@@ -599,7 +622,7 @@ Anju uses @code{context-menu-mode} (introduced in Emacs 28) to define its contex
 @code{click} : a mouse event
 @end itemize
 
-When the context menu is raised@comma{} typically via right-click (@code{mouse-3})@comma{} each function in @code{context-menu-functions} is run@comma{} populating the context menu.
+When the context menu is raised, typically via right-click (@code{mouse-3}), each function in @code{context-menu-functions} is run, populating the context menu.
 
 The following example Elisp illustrates an implementation of a context menu function.
 
@@ -633,7 +656,7 @@ At the time of menu item definition
 At a higher level.
 @end enumerate
 
-The @emph{context} is determined by a predicate which can take into account different things@comma{} among them:
+The @emph{context} is determined by a predicate which can take into account different things, among them:
 
 @itemize
 @item
@@ -646,7 +669,7 @@ Cursor (Point) position
 Mouse position
 @end itemize
 
-In the example above@comma{} the context predicate is @code{(derived-mode-p 'text-mode)}.  Note that it is defined at a higher level to avoid instantiating menu items if the context does not apply.
+In the example above, the context predicate is @code{(derived-mode-p 'text-mode)}.  Note that it is defined at a higher level to avoid instantiating menu items if the context does not apply.
 
 The context predicate can be embedded in the menu item definition itself. See more about this with the @code{:visible} and @code{:active} keywords for the macro @code{easy-menu-define}.
 
@@ -710,10 +733,10 @@ Open in Dired.
 
 @item @code{anju-context-menu-vc}
 Version control related commands.
-If Magit 4.4+ is installed@comma{} then calls to it are made from here.
+If Magit 4.4+ is installed, then calls to it are made from here.
 
 @item @code{anju-context-menu-markup}
-Commands to show/hide text markup (e.g. Org@comma{} Markdown).
+Commands to show/hide text markup (e.g. Org, Markdown).
 
 @item @code{anju-context-menu-wordcount}
 Word count command.
@@ -743,10 +766,10 @@ The pop-up buffer list menu can be customized two ways:
 
 @enumerate
 @item
-Customizing the variable @code{anju-buffer-list-filter-functions}@comma{} a list of filter functions that are run each time the pop-up menu is raised when left-clicking the mode line buffer name.
+Customizing the variable @code{anju-buffer-list-filter-functions}, a list of filter functions that are run each time the pop-up menu is raised when left-clicking the mode line buffer name.
 
 @item
-Customizing the variable @code{anju-mode-line-buffer-list-function}@comma{} which gives a user complete control on what is displayed in the pop-up menu.
+Customizing the variable @code{anju-mode-line-buffer-list-function}, which gives a user complete control on what is displayed in the pop-up menu.
 @end enumerate
 
 
@@ -754,7 +777,7 @@ Customizing the variable @code{anju-mode-line-buffer-list-function}@comma{} whic
 
 This variable is an alist used by the function @code{anju-buffer-list-menu-items} to populate the list of buffers used in the pop up menu @code{anju-popup-buffer-menu}.
 
-This alist is filled using the following key@comma{} value pair types:
+This alist is filled using the following key, value pair types:
 
 @table @asis
 @item key
@@ -809,24 +832,42 @@ Users who wish define their own menu should override this value with their own f
 @vindex anju-main-menu--reconfigure-text-mode
 @vindex anju-main-menu--reconfigure-bookmarks
 @vindex anju-main-menu--reconfigure-help
+@vindex anju-main-menu--reconfigure-imenu
 @vindex anju-help-menu-remove-emacs-tutorial
 
 Anju modifies the main menu via the customizable hook variable @code{anju-reconfigure-main-menu-hook}. This hook is run in the command @code{anju-init}.
 
-By default@comma{} the following hook functions are run:
+By default, the following hook functions are run:
 
 @table @asis
 @item @code{anju-main-menu--reconfigure-text-mode}
 Reconfigures Text menu for text mode buffers.
+
 @item @code{anju-main-menu--reconfigure-bookmarks}
 Adds Bookmarks menu to main menu.
+
 @item @code{anju-main-menu--reconfigure-help}
 Reconfigures Help menu.
 @itemize
 @item
 Set the customizable variable @code{anju-help-menu-remove-emacs-tutorial} to @code{t} if removing the tutorial entries is desired.
 @end itemize
+
+@item @code{anju-main-menu--reconfigure-imenu}
+Adds an index menu (imenu) to the following modes:
+@itemize
+@item
+@code{prog-mode}
+@item
+@code{makefile-mode}
+@item
+@code{org-mode}
+@item
+@code{markdown-mode}
+@end itemize
 @end table
+
+Execution of any of the above functions can be set to preference in @code{anju-reconfigure-main-menu-hook}.    
 
 @code{anju-reconfigure-main-menu-hook} can be modified to add additional custom hook functions. Users who wish to do this should familiarize themselves with menu keymaps (@ref{Menu Keymaps,elisp#Menu Keymaps,,elisp,}) and the Easy Menu (@ref{Easy Menu,elisp#Easy Menu,,elisp,}) library.
 
@@ -859,7 +900,7 @@ Support for more built-in modes
 Further changes to the main menu
 @end itemize
 
-Although much consideration on both the user and developer experience has been made@comma{} they are both subject to change in future releases if a better approach presents itself.
+Although much consideration on both the user and developer experience has been made, they are both subject to change in future releases if a better approach presents itself.
 
 @node Feedback & Discussion
 @chapter Feedback & Discussion
@@ -868,14 +909,14 @@ Although much consideration on both the user and developer experience has been m
 Please report any feedback about Anju to the @uref{https://github.com/kickingvegas/anju/issues, issue tracker on GitHub}.
 
 @cindex Discussion
-To participate in general discussion about using Anju@comma{} please join the @uref{https://github.com/kickingvegas/anju/discussions, discussion group}.
+To participate in general discussion about using Anju, please join the @uref{https://github.com/kickingvegas/anju/discussions, discussion group}.
 
 @node Sponsorship
 @chapter Sponsorship
 
 @cindex Sponsorship
 
-It costs money to make@comma{} enhance@comma{} and maintain Anju as ideologically free software. If you enjoy using Anju@comma{} please buy me a coffee to help support its development and maintenance.
+It costs money to make, enhance, and maintain Anju as ideologically free software. If you enjoy using Anju, please buy me a coffee to help support its development and maintenance.
 
 @image{images/default-yellow,,,,png}
 
@@ -886,7 +927,7 @@ It costs money to make@comma{} enhance@comma{} and maintain Anju as ideologicall
 
 @cindex About Anju
 
-@uref{https://github.com/kickingvegas/anju, Anju} was conceived and crafted by Charles Choi in San Francisco@comma{} California.
+@uref{https://github.com/kickingvegas/anju, Anju} was conceived and crafted by Charles Choi in San Francisco, California.
 
 Thank you for using Anju.
 
@@ -897,7 +938,7 @@ Always choose love.
 
 @cindex Acknowledgments
 
-Thanks goes out to the contributors to @code{mouse.el}@comma{} whose work this package builds upon.
+Thanks goes out to the contributors to @code{mouse.el}, whose work this package builds upon.
 
 @node Main Index
 @chapter Main Index
@@ -909,7 +950,7 @@ Index for this user guide.
 @node Variable Index
 @chapter Variable Index
 
-Variables@comma{} functions@comma{} commands@comma{} and menus referenced by this user guide.
+Variables, functions, commands, and menus referenced by this user guide.
 
 @printindex vr
 

--- a/lisp/anju-main-menu.el
+++ b/lisp/anju-main-menu.el
@@ -24,6 +24,9 @@
 
 ;;; Code:
 (require 'bookmark)
+(require 'make-mode)
+(require 'org)
+(require 'markdown-mode)
 (require 'anju-utils)
 (require 'anju-style-text)
 (require 'casual-bookmarks)
@@ -148,6 +151,49 @@
 
   (easy-menu-add-item text-mode-menu nil anju-transform-text-menu "Auto Fill")
   (easy-menu-add-item text-mode-menu nil anju-style-menu "Auto Fill"))
+
+
+
+;; -------------------------------------------------------------------
+;; Imenu Configuration
+
+
+(defun anju-imenu-add-menubar-index ()
+  "Add imenu index to menubar."
+  (condition-case err (imenu-add-menubar-index)
+    (imenu-unavailable
+     (let ((inhibit-message t))
+       (message "Warning: %s" (error-message-string err))))))
+
+(defun anju-imenu-auto-rescan ()
+  "Set local `imenu-auto-rescan' to t."
+  (setq-local imenu-auto-rescan t))
+
+(defun anju-main-menu--reconfigure-imenu ()
+  "Configure main menu to include index menu for different modes.
+
+Current modes affected:
+- `prog-mode'
+- `makefile-mode'
+- `org-mode'
+- `markdown-mode'
+
+Auto rescan `imenu-auto-rescan' is enabled for all affected modes."
+
+  (let ((hooks '(markdown-mode-hook
+                 makefile-mode-hook
+                 prog-mode-hook
+                 org-mode-hook)))
+
+    (mapc (lambda (hook)
+            (if (eq hook 'prog-mode-hook)
+                (add-hook hook #'anju-imenu-add-menubar-index)
+              (add-hook hook #'imenu-add-menubar-index))
+            (add-hook hook #'anju-imenu-auto-rescan))
+          hooks)
+
+    (if (<= org-imenu-depth 2)
+        (setopt org-imenu-depth 7))))
 
 (provide 'anju-main-menu)
 ;;; anju-main-menu.el ends here

--- a/lisp/anju-utils.el
+++ b/lisp/anju-utils.el
@@ -127,6 +127,9 @@ add their own filters to define the resulting buffer list returned by
 
   :type '(alist
           :key-type (choice (function-item anju-buffer-list-plain-filter)
+                            (function-item anju-buffer-list-compilation-filter)
+                            (function-item anju-buffer-list-grep-filter)
+                            (function-item anju-buffer-list-xref-filter)
                             (function-item anju-buffer-list-eshell-filter)
                             (function-item anju-buffer-list-shell-filter)
                             (function-item anju-buffer-list-info-filter)
@@ -138,12 +141,22 @@ add their own filters to define the resulting buffer list returned by
 (defcustom anju-reconfigure-main-menu-hook
   '(anju-main-menu--reconfigure-bookmarks
     anju-main-menu--reconfigure-text-mode
-    anju-main-menu--reconfigure-help)
-  "Main menu mode hooks to run in `anju-init'."
+    anju-main-menu--reconfigure-help
+    anju-main-menu--reconfigure-imenu)
+  "Main menu mode hooks to run in `anju-init'.
+
+This hook is a list of functions that reconfigure the main menu. It is
+initialized with the following functions:
+
+- `anju-main-menu--reconfigure-bookmarks'
+- `anju-main-menu--reconfigure-text-mode'
+- `anju-main-menu--reconfigure-help'
+- `anju-main-menu--reconfigure-imenu'"
   :type 'hook
   :options '(anju-main-menu--reconfigure-bookmarks
              anju-main-menu--reconfigure-text-mode
-             anju-main-menu--reconfigure-help)
+             anju-main-menu--reconfigure-help
+             anju-main-menu--reconfigure-imenu)
   :group 'anju)
 
 (defvar anju--frame-register-alist nil


### PR DESCRIPTION
* Adds an index menu (imenu) to the main menu for the following modes
  - prog-mode
  - makefile-mode
  - org-mode
  - markdown-mode

* lisp/anju-utils.el (anju-buffer-list-filter-functions): Fix: add missing
filters to choice selection
