### PR TITLE
Add delete-pair command to Edit menu

### DIFF
--- a/docs/anju.org
+++ b/docs/anju.org
@@ -347,10 +347,11 @@ The commands provided by the above additions to the *Edit* menu are shown below.
 - Delete
   - Join Line (~join-line~)
   - Just One Space (~just-one-space~)
-  - Delete Horizontal Space (~delete-horizontal-space~)
-  - Delete Blank Lines (~delete-blank-lines~)
+  - Horizontal Space (~delete-horizontal-space~)
+  - Pair (~delete-pair~)
+  - Blank Lines (~delete-blank-lines~)
   - Whitespace Cleanup (~whitespace-cleanup~)
-  - Delete Trailing Whitespace (~delete-trailing-whitespace~)
+  - Trailing Whitespace (~delete-trailing-whitespace~)
   - Zap up to… (~zap-up-to-char~)
   - Zap to… (~zap-to-char~)
     

--- a/docs/anju.texi
+++ b/docs/anju.texi
@@ -50,11 +50,11 @@ Support direct manipulation when possible
 Re-organization of the main menu bar
 @end itemize
 
-The features offered by Anju are opinionated, but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
+The features offered by Anju are opinionated@comma{} but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
 
 Please note that all UI terminology in this document is Emacs-centric and differs from conventional GUI terminology. Refer to (emacs) Frames (@ref{Frames,emacs#Frames,,emacs,}) for more detail on this.
 
-It costs money to make, enhance, and maintain Anju as ideologically free software. If you enjoy using Anju, please buy me a coffee to help support its development and maintenance.
+It costs money to make@comma{} enhance@comma{} and maintain Anju as ideologically free software. If you enjoy using Anju@comma{} please buy me a coffee to help support its development and maintenance.
 
 @image{images/default-yellow,,,,png}
 
@@ -156,7 +156,7 @@ Lengthy menus that feel more like an inventory of commands rather than a designe
 Over-reliance on mouse workflows that require switching between the mouse and keyboard.
 @end itemize
 
-Anju makes opinionated design decisions, but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
+Anju makes opinionated design decisions@comma{} but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
 
 Elaboration on what informs Anju's opinions is described below.
 
@@ -171,7 +171,7 @@ Elaboration on what informs Anju's opinions is described below.
 
 This section conveys the principles and concerns used by Anju to inform its design decisions.
 
-Editorially, all design decisions for Anju are ultimately the opinion of Charles Y@. Choi.
+Editorially@comma{} all design decisions for Anju are ultimately the opinion of Charles Y@. Choi.
 
 
 @subheading General Principles
@@ -186,18 +186,18 @@ A coherent information architecture should be conveyed.
 Balance between concision and discoverability should be made in a menu's offerings.
 @end itemize
 @item
-Nesting of sub-menus should be carefully considered, ideally not exceeding a depth of two.
+Nesting of sub-menus should be carefully considered@comma{} ideally not exceeding a depth of two.
 @item
 Mouse workflows that require keyboard input should be minimized.
 @item
-If the opportunity to provide a direct manipulation experience is available, it should be taken.
+If the opportunity to provide a direct manipulation experience is available@comma{} it should be taken.
 @item
 Unconventional mouse interactions should be avoided.
 @end itemize
 
 @subheading Concerns
 
-Anju takes the position that different types of menus have different concerns or objectives. This is most apparent in contrasting the design of a main menu section (e.g. File, Edit, Options, …) to that of a context menu.
+Anju takes the position that different types of menus have different concerns or objectives. This is most apparent in contrasting the design of a main menu section (e.g. File@comma{} Edit@comma{} Options@comma{} …) to that of a context menu.
 
 For Anju:
 
@@ -208,7 +208,7 @@ The highest concern of a main menu section is discoverability.
 The highest concern of a context menu is concision.
 @end itemize
 
-A common implementation practice in Emacs is to reuse menu keymaps for both the main menu and context menus. This violates the above concerns, which Anju seeks to address.
+A common implementation practice in Emacs is to reuse menu keymaps for both the main menu and context menus. This violates the above concerns@comma{} which Anju seeks to address.
 
 The next sub-sections further detail the design concerns with respect to an area where mouse interaction occurs.
 
@@ -233,11 +233,11 @@ Anju takes the opinion that context menus should @emph{not} support general comm
 
 @subsubheading Direct Manipulation
 
-Support for direct action based on mouse cursor position is a common user interaction technique. Anju applies this to Emacs window management, where window creation, deletion, and swapping are supported from both the context menu and the mode line.
+Support for direct action based on mouse cursor position is a common user interaction technique. Anju applies this to Emacs window management@comma{} where window creation@comma{} deletion@comma{} and swapping are supported from both the context menu and the mode line.
 
 @subsubheading No Middle Button Bindings
 
-Anju eschews Emacs' default middle mouse button bindings as they presume usage of a @uref{https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Sun_optical_mouse.jpg/960px-Sun_optical_mouse.jpg, 90's style 3-button mouse}. This style of mouse design has long been superseded with a middle @uref{https://upload.wikimedia.org/wikipedia/commons/2/22/3-Tasten-Maus_Microsoft.jpg, scroll-wheel+button control}. This widespread hardware change has resulted in the majority of mouse-supporting applications to emphasize scrolling actions with the middle control and clicking actions to the left and right buttons. Anju follows suit, primarily binding the right mouse button click (down) event to raising a context menu. In addition, Anju reconfigures commands that were previously bound to the middle button to ones accessible via a context menu.
+Anju eschews Emacs' default middle mouse button bindings as they presume usage of a @uref{https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Sun_optical_mouse.jpg/960px-Sun_optical_mouse.jpg, 90's style 3-button mouse}. This style of mouse design has long been superseded with a middle @uref{https://upload.wikimedia.org/wikipedia/commons/2/22/3-Tasten-Maus_Microsoft.jpg, scroll-wheel+button control}. This widespread hardware change has resulted in the majority of mouse-supporting applications to emphasize scrolling actions with the middle control and clicking actions to the left and right buttons. Anju follows suit@comma{} primarily binding the right mouse button click (down) event to raising a context menu. In addition@comma{} Anju reconfigures commands that were previously bound to the middle button to ones accessible via a context menu.
 
 The only exception Anju makes in this matter is to keep the Emacs default binding of @code{mouse-2} to @code{mouse-yank-primary}.
 
@@ -265,7 +265,7 @@ The following mode line enhancements are provided by Anju:
 @subheading Pop-up Buffer List
 @cindex Pop-up Buffer List
 
-On the mode line, left-click (@code{mouse-1}) on the buffer name to raise a pop-up menu containing a list of open buffers. The contents of this list is controlled by the customizable variable @code{anju-buffer-list-filter-functions}. More info on customizing the buffer list menu can be found in @ref{Mode Line Buffer List Menu Customization}.
+On the mode line@comma{} left-click (@code{mouse-1}) on the buffer name to raise a pop-up menu containing a list of open buffers. The contents of this list is controlled by the customizable variable @code{anju-buffer-list-filter-functions}. More info on customizing the buffer list menu can be found in @ref{Mode Line Buffer List Menu Customization, , Mode Line Buffer List Menu Customization}.
 
 
 @image{images/anju-mode-line-buffer-list,,,,png}
@@ -277,7 +277,7 @@ A right-click (@code{mouse-3}) on any blank space on the mode line will pop-up a
 
 @image{images/anju-mode-line-window-management,,,,png}
 
-From here, one can:
+From here@comma{} one can:
 @itemize
 @item
 Delete the window (×)
@@ -286,7 +286,7 @@ Split the window horizontally (→)
 @item
 Split the window vertically (↓)
 @item
-If multiple windows are shown, swap the current window.
+If multiple windows are shown@comma{} swap the current window.
 @end itemize
 
 Note: usage of ``window'' refers to the Emacs definition of it. Refer to @ref{Frames,emacs#Frames,,emacs,} for more detail on this.
@@ -294,7 +294,7 @@ Note: usage of ``window'' refers to the Emacs definition of it. Refer to @ref{Fr
 @subheading Toggle Maximize Window
 @cindex Toggle Maximize Window
 
-A left-double-click on any blank space on the mode line will checkpoint the current window configuration, then maximize the current window (@code{delete-other-windows}). Re-doing the left-double-click will restore the prior window configuration.
+A left-double-click on any blank space on the mode line will checkpoint the current window configuration@comma{} then maximize the current window (@code{delete-other-windows}). Re-doing the left-double-click will restore the prior window configuration.
 
 @node Context Menu Features
 @section Context Menu Features
@@ -317,10 +317,10 @@ Dired
 @item
 Window management
 @item
-Full support for @code{context-menu-mode} customization (See @ref{Context Menu Customization}).
+Full support for @code{context-menu-mode} customization (See @ref{Context Menu Customization, , Context Menu Customization}).
 @end itemize
 
-Anju deliberately omits the display of the default mode-specific menu keymaps in the context menu as they are considered redundant to their display in the main menu. Rationale for this is described in @ref{Design Principles and Concerns}. Users can still access the default mode-specific menu keymap by using the binding @kbd{C-<mouse-3>}.
+Anju deliberately omits the display of the default mode-specific menu keymaps in the context menu as they are considered redundant to their display in the main menu. Rationale for this is described in @ref{Design Principles and Concerns, , Design Principles and Concerns}. Users can still access the default mode-specific menu keymap by using the binding @kbd{C-<mouse-3>}.
 
 Learn more about the different areas Anju enhances context menus in the links below.
 
@@ -338,21 +338,21 @@ Learn more about the different areas Anju enhances context menus in the links be
 
 @image{images/anju-context-menu-region,,,,png}
 
-If a context menu is raised on selected text, the following menu items are displayed:
+If a context menu is raised on selected text@comma{} the following menu items are displayed:
 
 @table @asis
 @item Occur
 Run @code{occur} command to show occurrences of selected text.
 
 @item Style
-Applies mode-specific markup to emphasize the selected text (e.g. bold, italic, code, etc.).
+Applies mode-specific markup to emphasize the selected text (e.g. bold@comma{} italic@comma{} code@comma{} etc.).
 @itemize
 @item
 Available only for @code{org-mode} and @code{markdown-mode}.
 @end itemize
 
 @item Transform Text
-Applies transforms (upper/lower case, capitalize) to the selected text.
+Applies transforms (upper/lower case@comma{} capitalize) to the selected text.
 
 @item Toggle comment 
 Toggles selected text to be commented based on mode.
@@ -365,7 +365,7 @@ Available only on modes derived from @code{prog-mode} and @code{org-mode}
 Writes selected text to a user-specified file.
 
 @item Look Up
-If a word is selected, uses @code{dictionary} to look up its definition.
+If a word is selected@comma{} uses @code{dictionary} to look up its definition.
 @end table
 
 @node Org Mode Context Menu
@@ -384,9 +384,9 @@ Item
 Table
 @end itemize
 
-In addition if text is selected, then support for styling it is supported.
+In addition if text is selected@comma{} then support for styling it is supported.
 
-Note that the Org mode context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns}.
+Note that the Org mode context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns, , Design Principles and Concerns}.
 
 It is recommended that the @code{org-mouse} package be loaded when using
 
@@ -402,7 +402,7 @@ It is recommended that the @code{org-mouse} package be loaded when using
 
 @cindex Org Headline Context Menu
 
-If the context menu is raised on a headline, then commands related to clocking and promotion are offered.
+If the context menu is raised on a headline@comma{} then commands related to clocking and promotion are offered.
 
 @image{images/anju-context-menu-org-headline,,,,png}
 
@@ -411,13 +411,13 @@ If the context menu is raised on a headline, then commands related to clocking a
 
 @cindex Org Item Context Menu
 
-If the context menu is raised on a list item, then commands related to promotion and conversion to a checkbox are provided.
+If the context menu is raised on a list item@comma{} then commands related to promotion and conversion to a checkbox are provided.
 
-The menu item ``To Checkbox'' will convert an item to a checkbox, with the additional behavior that if the point is at the start of the whole list, the whole list will be turned into checkboxes.
+The menu item ``To Checkbox'' will convert an item to a checkbox@comma{} with the additional behavior that if the point is at the start of the whole list@comma{} the whole list will be turned into checkboxes.
 
 @image{images/anju-context-menu-org-item,,,,png}
 
-If @code{org-mouse} is loaded, then clicking on a checkbox will toggle its state between on ('[X]') or off ('[ ]'). However, changing to an intermediate state ('[-]') is supported by the menu item ``In-Progress''. The menu item ``To Item'' will convert the checkbox back to a plain list item.
+If @code{org-mouse} is loaded@comma{} then clicking on a checkbox will toggle its state between on ('[X]') or off ('[ ]'). However@comma{} changing to an intermediate state ('[-]') is supported by the menu item ``In-Progress''. The menu item ``To Item'' will convert the checkbox back to a plain list item.
 
 @image{images/anju-context-menu-org-checkbox,,,,png}
 
@@ -428,7 +428,7 @@ Note that checkboxes in screenshots are prettified using @code{prettify-symbols-
 
 @cindex Org Table Context Menu
 
-If the context menu is raised in a table, then table-specific commands are shown.
+If the context menu is raised in a table@comma{} then table-specific commands are shown.
 
 @image{images/anju-context-menu-org-table,,,,png}
 
@@ -443,13 +443,13 @@ Anju adds more “Paste” commands that will display given the right context.
 
 @table @asis
 @item Paste Last Org Link
-If it exists, this command will insert the last stored Org link.
+If it exists@comma{} this command will insert the last stored Org link.
 
 @item Paste Markdown as Org
-If the clipboard (latest yank) is known by the user to be Markdown text, this command will convert the clipboard text to Org via @code{pandoc}, then paste (yank) it into the buffer.
+If the clipboard (latest yank) is known by the user to be Markdown text@comma{} this command will convert the clipboard text to Org via @code{pandoc}@comma{} then paste (yank) it into the buffer.
 
 @item Paste Media
-If an image as been copied into the clipboard, this menu item will ``paste'' it via the @code{yank-media} command.
+If an image as been copied into the clipboard@comma{} this menu item will ``paste'' it via the @code{yank-media} command.
 @end table
 
 @node Dired Mode Context Menu
@@ -461,25 +461,25 @@ Anju has context menu support for Dired mode. The screenshot below shows the con
 
 @image{images/anju-dired-copy-to,,,,png}
 
-If the mouse point is over a directory, the option to insert a view (aka subdir) for it in the buffer is provided.
+If the mouse point is over a directory@comma{} the option to insert a view (aka subdir) for it in the buffer is provided.
 
 @image{images/anju-dired-insert-subdir,,,,png}
 
-Note that the Dired context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns}.
+Note that the Dired context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns, , Design Principles and Concerns}.
 
 @node Magit Support
 @subsection Magit Support
 
 @cindex Magit Support
 
-If Magit 4.4+ is installed, then the context menu function @code{anju-context-menu-vc} will offer Magit commands depending on context. If the context menu is raised in a file buffer, then the menu item ``Magit Dispatch…'' (@code{magit-file-dispatch}) is shown, otherwise ``Magit Status'' (@code{magit-status}).
+If Magit 4.4+ is installed@comma{} then the context menu function @code{anju-context-menu-vc} will offer Magit commands depending on context. If the context menu is raised in a file buffer@comma{} then the menu item ``Magit Dispatch…'' (@code{magit-file-dispatch}) is shown@comma{} otherwise ``Magit Status'' (@code{magit-status}).
 
 @node Main Menu Features
 @section Main Menu Features
 
 @cindex Main Menu Features
 
-Anju enhances the main menu bar of Emacs by making opinionated changes to its existing menus as well as adding several new ones. These changes are configurable per menu in the main menu (e.g. ``File'', ``Edit'', ``Options'', etc.). For more detail, see @ref{Main Menu Customization}.
+Anju enhances the main menu bar of Emacs by making opinionated changes to its existing menus as well as adding several new ones. These changes are configurable per menu in the main menu (e.g. ``File''@comma{} ``Edit''@comma{} ``Options''@comma{} etc.). For more detail@comma{} see @ref{Main Menu Customization, , Main Menu Customization}.
 
 @menu
 * File Menu Features::
@@ -507,9 +507,9 @@ Updates the “New Frame on Display Server@dots{}” menu item to only display o
 Updates the “New Frame on Monitor…” menu item to only display if more than one monitor is detected.
 @end itemize
 
-For the macOS NS variant of Emacs, the above update to “New Frame on Monitor…” will only work on Emacs version 31+.
+For the macOS NS variant of Emacs@comma{} the above update to “New Frame on Monitor…” will only work on Emacs version 31+.
 
-These modifications are optional. For more detail, see @ref{File Menu Customization}.
+These modifications are optional. For more detail@comma{} see @ref{File Menu Customization, , File Menu Customization}.
 
 @node Edit Menu Features
 @subsection Edit Menu Features
@@ -543,7 +543,7 @@ Adds the menu item “Keep Lines…”.
 Adds the menu item “Duplicate”.
 @end itemize
 
-On the macOS NS variant of Emacs, the following menu items are added.
+On the macOS NS variant of Emacs@comma{} the following menu items are added.
 
 @itemize
 @item
@@ -609,13 +609,15 @@ Join Line (@code{join-line})
 @item
 Just One Space (@code{just-one-space})
 @item
-Delete Horizontal Space (@code{delete-horizontal-space})
+Horizontal Space (@code{delete-horizontal-space})
 @item
-Delete Blank Lines (@code{delete-blank-lines})
+Pair (@code{delete-pair})
+@item
+Blank Lines (@code{delete-blank-lines})
 @item
 Whitespace Cleanup (@code{whitespace-cleanup})
 @item
-Delete Trailing Whitespace (@code{delete-trailing-whitespace})
+Trailing Whitespace (@code{delete-trailing-whitespace})
 @item
 Zap up to… (@code{zap-up-to-char})
 @item
@@ -641,16 +643,16 @@ Emoji & Symbols (@code{ns-do-show-character-palette}) (only on macOS NS)
 
 Note that a menu command can be run again immediately after it has been issued using the @code{repeat} command (binding @kbd{C-x z}). This is useful when using the move text commands.
 
-These modifications are optional. For more detail, see @ref{Edit Menu Customization}.
+These modifications are optional. For more detail@comma{} see @ref{Edit Menu Customization, , Edit Menu Customization}.
 
 @node Options Menu Features
 @subsection Options Menu Features
 
 @cindex Options Menu Features
 
-Anju makes the presumption that most Emacs users do not use the CUA mode configuration in the main menu bar @strong{Options} menu. As such, the “Cut/Paste with C-x/C-c/C-v (CUA Mode)” menu item is removed.
+Anju makes the presumption that most Emacs users do not use the CUA mode configuration in the main menu bar @strong{Options} menu. As such@comma{} the “Cut/Paste with C-x/C-c/C-v (CUA Mode)” menu item is removed.
 
-This modification is optional. For more detail, see @ref{Options Menu Customization}.
+This modification is optional. For more detail@comma{} see @ref{Options Menu Customization, , Options Menu Customization}.
 
 @node Bookmarks Menu Features
 @subsection Bookmarks Menu Features
@@ -661,7 +663,7 @@ Anju adds a @strong{Bookmarks} menu to the main menu to work with Emacs-specific
 
 @image{images/anju-main-menu-bookmarks,,,,png}
 
-This modification is optional. For more detail, see @ref{Bookmarks Menu Customization}.
+This modification is optional. For more detail@comma{} see @ref{Bookmarks Menu Customization, , Bookmarks Menu Customization}.
 
 The menu hierarchy of the @strong{Bookmarks} menu is described below with the actual command shown in parenthesis next to its label.
 
@@ -681,7 +683,7 @@ Jump to Bookmark… (@code{bookmark-jump})
 
 @image{images/anju-main-menu-text,,,,png}
 
-If the major mode of the current buffer is derived from @code{text-mode}, then a @strong{Text} menu is displayed in the main menu bar.
+If the major mode of the current buffer is derived from @code{text-mode}@comma{} then a @strong{Text} menu is displayed in the main menu bar.
 
 The menu hierarchy of the @strong{Text} menu is described below with the actual command shown in parenthesis next to its label.
 
@@ -748,7 +750,7 @@ Auto Fill (@code{toggle-text-mode-auto-fill})
 
 Note the @strong{Style} menu is visible only for Org and Markdown modes.
 
-This modification is optional. For more detail, see @ref{Text Menu Customization}.
+This modification is optional. For more detail@comma{} see @ref{Text Menu Customization, , Text Menu Customization}.
 
 @node Index Menu (imenu) Features
 @subsection Index Menu (imenu) Features
@@ -758,7 +760,7 @@ This modification is optional. For more detail, see @ref{Text Menu Customization
 @image{images/anju-main-menu-imenu,,,,png}
 
 
-For certain modes that support Imenu (@ref{Imenu,emacs#Imenu,,emacs,}), Anju will add an @strong{Index} menu to the main menu bar via the function  @code{imenu-add-menubar-index}.
+For certain modes that support Imenu (@ref{Imenu,emacs#Imenu,,emacs,})@comma{} Anju will add an @strong{Index} menu to the main menu bar via the function  @code{imenu-add-menubar-index}.
 
 Modes supported this way by Anju are:
 
@@ -773,20 +775,20 @@ Modes supported this way by Anju are:
 @code{makefile-mode}
 @end itemize
 
-This modification is optional. For more detail, see @ref{Imenu Menu Customization}.
+This modification is optional. For more detail@comma{} see @ref{Imenu Menu Customization, , Imenu Menu Customization}.
 
 @node Help Menu Features
 @subsection Help Menu Features
 
 @cindex Help Menu Features
 
-Anju re-organizes the @strong{Help} menu as shown below. The re-organization emphasizes showing documentation in a new frame, takes out non-help related menu items, and offers more concision.
+Anju re-organizes the @strong{Help} menu as shown below. The re-organization emphasizes showing documentation in a new frame@comma{} takes out non-help related menu items@comma{} and offers more concision.
 
 @image{images/anju-main-menu-help,,,,png}
 
-This modification is optional. For more detail, see @ref{Help Menu Customization}.
+This modification is optional. For more detail@comma{} see @ref{Help Menu Customization, , Help Menu Customization}.
 
-For experienced users, the ``Emacs Tutorial'' menu items can be removed via the customizable variable @code{anju-help-menu-remove-emacs-tutorial}.
+For experienced users@comma{} the ``Emacs Tutorial'' menu items can be removed via the customizable variable @code{anju-help-menu-remove-emacs-tutorial}.
 
 @node Window Management Features
 @section Window Management Features
@@ -800,7 +802,7 @@ Window management via mouse interaction is provided for through the @ref{Mode Li
 
 @cindex Requirements
 
-Anju requires Emacs 29.1+, Casual 2.13+, Markdown Mode 2.7+.
+Anju requires Emacs 29.1+@comma{} Casual 2.13+@comma{} Markdown Mode 2.7+.
 
 Certain menus require more installed software:
 
@@ -840,9 +842,9 @@ Call @code{anju-init} in your Emacs initialization file.
 @end lisp
 @end enumerate
 
-Anju supports a high degree of customization. Users who wish this should make a deep read of the @ref{Customization} section.
+Anju supports a high degree of customization. Users who wish this should make a deep read of the @ref{Customization, , Customization} section.
 
-While not required, the following additions to your Emacs initialization file can further enhance your mouse experience:
+While not required@comma{} the following additions to your Emacs initialization file can further enhance your mouse experience:
 
 @itemize
 @item
@@ -855,7 +857,7 @@ Enable @code{org-mouse}
 Add Markdown export support to Org mode
 @itemize
 @item
-@code{M-x} @code{customize-variable} @code{org-export-backends}, check @code{md} option.
+@code{M-x} @code{customize-variable} @code{org-export-backends}@comma{} check @code{md} option.
 @end itemize
 
 @item
@@ -866,7 +868,7 @@ Globally bind @code{C-x 1} to @code{anju-toggle-one-window}.
 @end lisp
 
 @item
-Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog interactions, or @code{nil} to always get a mini-buffer prompt.
+Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog interactions@comma{} or @code{nil} to always get a mini-buffer prompt.
 @end itemize
 
 @node Customization
@@ -874,7 +876,7 @@ Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog inter
 
 @cindex Customization
 
-Anju provides a number of ways to customize mouse interactions in Emacs. In many cases, Anju leverages off existing Emacs customization options, particularly around defining and modifying menus. Users who wish to modify menus in Emacs should familiarize themselves with menu keymaps (@ref{Menu Keymaps,elisp#Menu Keymaps,,elisp,}) and the Easy Menu (@ref{Easy Menu,elisp#Easy Menu,,elisp,}) library.
+Anju provides a number of ways to customize mouse interactions in Emacs. In many cases@comma{} Anju leverages off existing Emacs customization options@comma{} particularly around defining and modifying menus. Users who wish to modify menus in Emacs should familiarize themselves with menu keymaps (@ref{Menu Keymaps,elisp#Menu Keymaps,,elisp,}) and the Easy Menu (@ref{Easy Menu,elisp#Easy Menu,,elisp,}) library.
 
 Customization options for the different areas Anju covers are detailed below.
 
@@ -914,18 +916,18 @@ Remove bindings using @code{mouse-2}.
 @item @code{anju-reconfigure-main-menu-enable}
 Top-level variable to reconfigure the main menu.
 
-If @code{anju-reconfigure-main-menu-enable} is @code{t}, the following variables determine how the main menu is reconfigured:
+If @code{anju-reconfigure-main-menu-enable} is @code{t}@comma{} the following variables determine how the main menu is reconfigured:
 
 @table @asis
 @item @code{anju-reconfigure-main-menu-hook}
-a list of functions, each modifying a menu of the main menu.
+a list of functions@comma{} each modifying a menu of the main menu.
 
 @item @code{anju-help-menu-remove-emacs-tutorial}
 control if the Emacs tutorial menu items are shown.
 @end table
 @end table
 
-By default, all the above @code{*-enable} variables are set to @code{t}.  Users preferring to make granular changes to @code{anju-init} can invoke @code{M-x} @code{customize-group} @code{anju}.
+By default@comma{} all the above @code{*-enable} variables are set to @code{t}.  Users preferring to make granular changes to @code{anju-init} can invoke @code{M-x} @code{customize-group} @code{anju}.
 
 @node Context Menu Customization
 @section Context Menu Customization
@@ -946,7 +948,7 @@ Anju uses @code{context-menu-mode} (introduced in Emacs 28) to define its contex
 @code{click} : a mouse event
 @end itemize
 
-When the context menu is raised, typically via right-click (@code{mouse-3}), each function in @code{context-menu-functions} is run, populating the context menu.
+When the context menu is raised@comma{} typically via right-click (@code{mouse-3})@comma{} each function in @code{context-menu-functions} is run@comma{} populating the context menu.
 
 The following example Elisp illustrates an implementation of a context menu function.
 
@@ -978,7 +980,7 @@ At the time of menu item definition
 At a higher level.
 @end enumerate
 
-The @emph{context} is determined by a predicate which can take into account different things, among them:
+The @emph{context} is determined by a predicate which can take into account different things@comma{} among them:
 
 @itemize
 @item
@@ -991,7 +993,7 @@ Cursor (Point) position
 Mouse position
 @end itemize
 
-In the example above, the context predicate tests if the major mode is derived from @code{text-mode} @emph{and} if point is not inside an Org table (@code{anju-at-org-table-p}).  Note that it is defined at a higher level to avoid instantiating menu items if the context does not apply.
+In the example above@comma{} the context predicate tests if the major mode is derived from @code{text-mode} @emph{and} if point is not inside an Org table (@code{anju-at-org-table-p}).  Note that it is defined at a higher level to avoid instantiating menu items if the context does not apply.
 
 The context predicate can be embedded in the menu item definition itself. See more about this with the @code{:visible} and @code{:active} keywords for the macro @code{easy-menu-define} (@ref{Easy Menu,elisp#Easy Menu,,elisp,}).
 
@@ -1063,10 +1065,10 @@ Open in Dired.
 
 @item @code{anju-context-menu-vc}
 Version control related commands.
-If Magit 4.4+ is installed, then calls to it are made from here.
+If Magit 4.4+ is installed@comma{} then calls to it are made from here.
 
 @item @code{anju-context-menu-markup}
-Commands to show/hide text markup (e.g. Org, Markdown).
+Commands to show/hide text markup (e.g. Org@comma{} Markdown).
 
 @item @code{anju-context-menu-wordcount}
 Word count command.
@@ -1096,10 +1098,10 @@ The pop-up buffer list menu can be customized two ways:
 
 @enumerate
 @item
-Customizing the variable @code{anju-buffer-list-filter-functions}, a list of filter functions that are run each time the pop-up menu is raised when left-clicking the mode line buffer name.
+Customizing the variable @code{anju-buffer-list-filter-functions}@comma{} a list of filter functions that are run each time the pop-up menu is raised when left-clicking the mode line buffer name.
 
 @item
-Customizing the variable @code{anju-mode-line-buffer-list-function}, which gives a user complete control on what is displayed in the pop-up menu.
+Customizing the variable @code{anju-mode-line-buffer-list-function}@comma{} which gives a user complete control on what is displayed in the pop-up menu.
 @end enumerate
 
 
@@ -1107,7 +1109,7 @@ Customizing the variable @code{anju-mode-line-buffer-list-function}, which gives
 
 This variable is an alist used by the function @code{anju-buffer-list-menu-items} to populate the list of buffers used in the pop up menu @code{anju-popup-buffer-menu}.
 
-This alist is filled using the following key, value pair types:
+This alist is filled using the following key@comma{} value pair types:
 
 @table @asis
 @item key
@@ -1162,7 +1164,7 @@ Users who wish define their own menu should override this value with their own f
 
 Anju uses the customizable hook variable @code{anju-reconfigure-main-menu-hook} to customize the main menu bar.
 
-@code{anju-reconfigure-main-menu-hook} is a list of hook functions,  where each function is designed to modify a different menu of the main menu bar (e.g. ``File'', ``Edit'', ``Options'', etc.). This hook is run in the command @code{anju-init}.
+@code{anju-reconfigure-main-menu-hook} is a list of hook functions@comma{}  where each function is designed to modify a different menu of the main menu bar (e.g. ``File''@comma{} ``Edit''@comma{} ``Options''@comma{} etc.). This hook is run in the command @code{anju-init}.
 
 Detailed below are the different hook functions provided for by Anju.
 
@@ -1196,7 +1198,7 @@ Enabling @code{anju-main-menu--reconfigure-file} can be done using the checkbox 
 
 @table @asis
 @item @code{anju-file-menu-replace-make-frame-on}
-If non-nil, the following menu items are replaced with more context-specific behavior:
+If non-nil@comma{} the following menu items are replaced with more context-specific behavior:
 
 @itemize
 @item
@@ -1263,7 +1265,7 @@ Enabling @code{anju-main-menu--reconfigure-help} can be done using the checkbox 
 
 @table @asis
 @item @code{anju-help-menu-remove-emacs-tutorial}
-if non-nil, then remove the Emacs tutorial menu items. (default @code{t})
+if non-nil@comma{} then remove the Emacs tutorial menu items. (default @code{t})
 @end table
 
 @node Imenu Menu Customization
@@ -1305,7 +1307,7 @@ Support for more built-in modes
 Further changes to the main menu
 @end itemize
 
-Although much consideration on both the user and developer experience has been made, they are both subject to change in future releases if a better approach presents itself.
+Although much consideration on both the user and developer experience has been made@comma{} they are both subject to change in future releases if a better approach presents itself.
 
 @node Feedback & Discussion
 @chapter Feedback & Discussion
@@ -1314,14 +1316,14 @@ Although much consideration on both the user and developer experience has been m
 Please report any feedback about Anju to the @uref{https://github.com/kickingvegas/anju/issues, issue tracker on GitHub}.
 
 @cindex Discussion
-To participate in general discussion about using Anju, please join the @uref{https://github.com/kickingvegas/anju/discussions, discussion group}.
+To participate in general discussion about using Anju@comma{} please join the @uref{https://github.com/kickingvegas/anju/discussions, discussion group}.
 
 @node Sponsorship
 @chapter Sponsorship
 
 @cindex Sponsorship
 
-It costs money to make, enhance, and maintain Anju as ideologically free software. If you enjoy using Anju, please buy me a coffee to help support its development and maintenance.
+It costs money to make@comma{} enhance@comma{} and maintain Anju as ideologically free software. If you enjoy using Anju@comma{} please buy me a coffee to help support its development and maintenance.
 
 @image{images/default-yellow,,,,png}
 
@@ -1332,7 +1334,7 @@ It costs money to make, enhance, and maintain Anju as ideologically free softwar
 
 @cindex About Anju
 
-@uref{https://github.com/kickingvegas/anju, Anju} was conceived and crafted by Charles Choi in San Francisco, California.
+@uref{https://github.com/kickingvegas/anju, Anju} was conceived and crafted by Charles Choi in San Francisco@comma{} California.
 
 Thank you for using Anju.
 
@@ -1343,7 +1345,7 @@ Always choose love.
 
 @cindex Acknowledgments
 
-Thanks goes out to the contributors to @code{mouse.el}, whose work this package builds upon.
+Thanks goes out to the contributors to @code{mouse.el}@comma{} whose work this package builds upon.
 
 @node Main Index
 @chapter Main Index
@@ -1355,7 +1357,7 @@ Index for this user guide.
 @node Variable Index
 @chapter Variable Index
 
-Variables, functions, commands, and menus referenced by this user guide.
+Variables@comma{} functions@comma{} commands@comma{} and menus referenced by this user guide.
 
 @printindex vr
 

--- a/lisp/anju-main-menu.el
+++ b/lisp/anju-main-menu.el
@@ -170,17 +170,20 @@ whitespace at join"]
      :help "Delete all spaces and tabs around point, leaving \
 one space"]
 
-    ["Delete Horizontal Space" delete-horizontal-space
+    ["Horizontal Space" delete-horizontal-space
      :help "Delete all spaces and tabs around point"]
 
-    ["Delete Blank Lines" delete-blank-lines
+    ["Pair" delete-pair
+     :help "Delete a pair of characters enclosing ARG sexps that follow point"]
+
+    ["Blank Lines" delete-blank-lines
      :help "On blank line, delete all surrounding blank lines, \
 leaving just one"]
 
     ["Whitespace Cleanup" whitespace-cleanup
      :help "Cleanup some blank problems in all buffer or at region"]
 
-    ["Delete Trailing Whitespace" delete-trailing-whitespace
+    ["Trailing Whitespace" delete-trailing-whitespace
      :help "Delete trailing whitespace between START and END"]
 
     ["Zap up to…" zap-up-to-char

--- a/tests/test-anju-main-menu.el
+++ b/tests/test-anju-main-menu.el
@@ -187,7 +187,7 @@ one sexp")))))
   (anju-test-keymap
    kmap
    "Delete"
-   8
+   9
    (lambda (items)
      (let ((i 0))
        (anju-test-menu-item
@@ -206,13 +206,19 @@ one space")
 
        (anju-test-menu-item
         (seq-elt items (cl-incf i))
-        "Delete Horizontal Space"
+        "Horizontal Space"
         #'delete-horizontal-space
         "Delete all spaces and tabs around point")
 
        (anju-test-menu-item
         (seq-elt items (cl-incf i))
-        "Delete Blank Lines"
+        "Pair"
+        #'delete-pair
+        "Delete a pair of characters enclosing ARG sexps that follow point")
+
+       (anju-test-menu-item
+        (seq-elt items (cl-incf i))
+        "Blank Lines"
         #'delete-blank-lines
         "On blank line, delete all surrounding blank lines, \
 leaving just one")
@@ -225,10 +231,9 @@ leaving just one")
 
        (anju-test-menu-item
         (seq-elt items (cl-incf i))
-        "Delete Trailing Whitespace"
+        "Trailing Whitespace"
         #'delete-trailing-whitespace
         "Delete trailing whitespace between START and END")
-
 
        (anju-test-menu-item
         (seq-elt items (cl-incf i))


### PR DESCRIPTION
* lisp/anju-main-menu.el (anju-delete-space-menu):
  - Adds `delete-pair` command.
  - Remove "Delete" word from menu item labels.

* tests/test-anju-main-menu.el (test--anju-delete-space-menu):
  - Update unit test.

* docs/anju.org (Edit Menu Features):
  - Update documentation.
