### PR TITLE
Change mode line pop-up buffer-name menu to prioritize project files

### DIFF
--- a/docs/anju.org
+++ b/docs/anju.org
@@ -270,7 +270,7 @@ Note that the Dired context menu is intentionally restrained in its command offe
 *** Emacs Lisp Context Menu
 #+CINDEX: Emacs Lisp Context Menu
 
-Anju enhances the context menu for Emacs Lisp (Elisp) development with support for Edebug and ERT. 
+Anju enhances the context menu for Emacs Lisp (Elisp) development with support for Edebug and ERT.
 
 
 **** Basic Elisp Context Menu
@@ -299,9 +299,9 @@ When debugging Elisp using Edebug, the following context menu offering its many 
 
 [[file:images/anju-context-menu-edebug.png]]
 
-For users new to Edebug, it is helpful to understand that code execution is sexp-based as opposed to line/function-based in other IDEs. 
+For users new to Edebug, it is helpful to understand that code execution is sexp-based as opposed to line/function-based in other IDEs.
 
-To better understand Edebug's command set, a close reading of its manual is recommended ([[info:elisp#Edebug]]). 
+To better understand Edebug's command set, a close reading of its manual is recommended ([[info:elisp#Edebug]]).
 
 
 **** ERT Support
@@ -444,11 +444,11 @@ The commands provided by the above additions to the *Edit* menu are shown below.
   - Trailing Whitespace (~delete-trailing-whitespace~)
   - Zap up to… (~zap-up-to-char~)
   - Zap to… (~zap-to-char~)
-    
+
 - Flush Lines… (~flush-lines~)
 
 - Keep Lines… (~keep-lines~)
-  
+
 - Align Regexp… (~align-regexp~)
 
 - Duplicate (~duplicate-dwim~)
@@ -456,7 +456,7 @@ The commands provided by the above additions to the *Edit* menu are shown below.
 - Colors (~ns-popup-color-panel~) (only on  macOS NS)
 
 - Emoji & Symbols (~ns-do-show-character-palette~) (only on macOS NS)
-  
+
 
 Note that a menu command can be run again immediately after it has been issued using the ~repeat~ command (binding {{{kbd(C-x z)}}}). This is useful when using the move text commands.
 
@@ -785,6 +785,7 @@ Anju provides the following context menu functions for convenience. They can be 
 #+VINDEX: anju-buffer-list-filter-functions
 #+VINDEX: anju-mode-line-buffer-list-function
 #+VINDEX: anju-buffer-list-plain-filter
+#+VINDEX: anju-buffer-list-project-filter
 #+VINDEX: anju-buffer-list-compilation-filter
 #+VINDEX: anju-buffer-list-grep-filter
 #+VINDEX: anju-buffer-list-xref-filter
@@ -818,6 +819,7 @@ at the front of the list.
 
 Anju provides the following buffer filters:
 
+- ~anju-buffer-list-project-filter~ :: buffers within the same project whose name is not marked as special (a name wrapped in ‘*’).
 - ~anju-buffer-list-plain-filter~ :: buffers whose name is not marked as special (a name wrapped in ‘*’).
 - ~anju-buffer-list-compilation-filter~ :: buffers whose major mode is ~compilation-mode~.
 - ~anju-buffer-list-grep-filter~ :: buffers whose major mode is ~grep-mode~.
@@ -828,6 +830,17 @@ Anju provides the following buffer filters:
 - ~anju-buffer-list-help-filter~ :: buffers whose major mode is ~help-mode~.
 
 Users can customize ~anju-buffer-list-filter-functions~ to re-compose or add their own filters to define the resulting buffer list returned by ~anju-buffer-list-menu-items~. It is recommended that the ~customize-variable~ command be used to accomplish this.
+
+By default ~anju-buffer-list-filter-functions~ contains the following filters:
+
+- ~anju-buffer-list-project-filter~
+- ~anju-buffer-list-compilation-filter~
+- ~anju-buffer-list-grep-filter~
+- ~anju-buffer-list-xref-filter~
+- ~anju-buffer-list-eshell-filter~
+- ~anju-buffer-list-shell-filter~
+- ~anju-buffer-list-info-filter~
+- ~anju-buffer-list-help-filter~
 
 #+TEXINFO: @subheading anju-mode-line-buffer-list-function
 #+VINDEX: anju-mode-line-buffer-list-function

--- a/docs/anju.texi
+++ b/docs/anju.texi
@@ -483,7 +483,7 @@ Note that the Dired context menu is intentionally restrained in its command offe
 
 @cindex Emacs Lisp Context Menu
 
-Anju enhances the context menu for Emacs Lisp (Elisp) development with support for Edebug and ERT@. 
+Anju enhances the context menu for Emacs Lisp (Elisp) development with support for Edebug and ERT@.
 
 @menu
 * Basic Elisp Context Menu::
@@ -518,7 +518,7 @@ When debugging Elisp using Edebug@comma{} the following context menu offering it
 
 @image{images/anju-context-menu-edebug,,,,png}
 
-For users new to Edebug@comma{} it is helpful to understand that code execution is sexp-based as opposed to line/function-based in other IDEs. 
+For users new to Edebug@comma{} it is helpful to understand that code execution is sexp-based as opposed to line/function-based in other IDEs.
 
 To better understand Edebug's command set@comma{} a close reading of its manual is recommended (@ref{Edebug,,,elisp,}).
 
@@ -657,7 +657,6 @@ On the macOS NS variant of Emacs@comma{} the following menu items are added.
 @item
 “Emoji & Symbols” - display the macOS system Emoji & Symbols dialog.
 @end itemize
-
 
 The commands provided by the above additions to the @strong{Edit} menu are shown below.
 
@@ -1228,6 +1227,7 @@ Rectangle commands.
 @vindex anju-buffer-list-filter-functions
 @vindex anju-mode-line-buffer-list-function
 @vindex anju-buffer-list-plain-filter
+@vindex anju-buffer-list-project-filter
 @vindex anju-buffer-list-compilation-filter
 @vindex anju-buffer-list-grep-filter
 @vindex anju-buffer-list-xref-filter
@@ -1270,6 +1270,8 @@ at the front of the list.
 Anju provides the following buffer filters:
 
 @table @asis
+@item @code{anju-buffer-list-project-filter}
+buffers within the same project whose name is not marked as special (a name wrapped in ‘*’).
 @item @code{anju-buffer-list-plain-filter}
 buffers whose name is not marked as special (a name wrapped in ‘*’).
 @item @code{anju-buffer-list-compilation-filter}
@@ -1289,6 +1291,27 @@ buffers whose major mode is @code{help-mode}.
 @end table
 
 Users can customize @code{anju-buffer-list-filter-functions} to re-compose or add their own filters to define the resulting buffer list returned by @code{anju-buffer-list-menu-items}. It is recommended that the @code{customize-variable} command be used to accomplish this.
+
+By default @code{anju-buffer-list-filter-functions} contains the following filters:
+
+@itemize
+@item
+@code{anju-buffer-list-project-filter}
+@item
+@code{anju-buffer-list-compilation-filter}
+@item
+@code{anju-buffer-list-grep-filter}
+@item
+@code{anju-buffer-list-xref-filter}
+@item
+@code{anju-buffer-list-eshell-filter}
+@item
+@code{anju-buffer-list-shell-filter}
+@item
+@code{anju-buffer-list-info-filter}
+@item
+@code{anju-buffer-list-help-filter}
+@end itemize
 
 @subheading anju-mode-line-buffer-list-function
 @vindex anju-mode-line-buffer-list-function

--- a/lisp/anju-mode-line.el
+++ b/lisp/anju-mode-line.el
@@ -23,6 +23,7 @@
 ;;
 
 ;;; Code:
+(require 'project)
 (require 'anju-utils)
 
 (defcustom anju-mode-line-buffer-list-function #'anju-buffer-list-menu-items
@@ -158,6 +159,30 @@ Derived from code found at URL
   (with-current-buffer buf
     (eq (derived-mode-p major-mode) 'xref--xref-buffer-mode)))
 
+(defun anju-filter-buffers-in-directory (buffers dir)
+  "Filter BUFFERS whose default directory is DIR."
+  (let ((dir (expand-file-name dir)))
+    (seq-filter (lambda (b)
+                  (let ((bdir (expand-file-name
+                               (buffer-local-value 'default-directory b))))
+                    (string-match dir bdir)))
+                buffers)))
+
+(defun anju-buffer-list-project-filter (buffers &optional count)
+  "Filter BUFFERS using `project-current', taking the first COUNT if defined.
+
+First filter BUFFERS through `anju-temporary-buffer-filter' and then
+filter remaining buffers using the root directory of `project-current'.
+If there is no project, then `default-directory' is used."
+  (let* ((buffers (seq-filter #'anju-temporary-buffer-filter buffers))
+         (curdir (if (project-current)
+                     (project-root (project-current))
+                   default-directory))
+         (buffers (anju-filter-buffers-in-directory buffers curdir)))
+    (if count
+        (seq-take buffers count)
+      buffers)))
+
 (defun anju-buffer-list-plain-filter (buffers &optional count)
   "Filter BUFFERS for plain names only, taking the first COUNT if defined."
   (anju-buffer-list--filter #'anju-temporary-buffer-filter buffers count))
@@ -215,8 +240,8 @@ This function called by indirection via the variable
 `anju-mode-line-buffer-list-function'."
 
   (let* ((open-buffers (buffer-list))
-         (all-buffers (anju-process-buffer-list-filter-functions open-buffers))
-         (all-buffers (remove (current-buffer) all-buffers))
+         (all-buffers (remove (current-buffer) open-buffers))
+         (all-buffers (anju-process-buffer-list-filter-functions all-buffers))
          (buffer-items (mapcar (lambda (buf)
                                  (vector (format "%s" (buffer-name buf))
                                          `(lambda () (interactive) (switch-to-buffer ,buf))

--- a/lisp/anju-utils.el
+++ b/lisp/anju-utils.el
@@ -92,7 +92,7 @@ nil and restart Emacs."
   :group 'anju)
 
 (defcustom anju-buffer-list-filter-functions
-  '((anju-buffer-list-plain-filter . 7)
+  '((anju-buffer-list-project-filter . 7)
     (anju-buffer-list-compilation-filter . 3)
     (anju-buffer-list-grep-filter . 3)
     (anju-buffer-list-xref-filter . 3)

--- a/tests/test-anju-utils.el
+++ b/tests/test-anju-utils.el
@@ -60,7 +60,7 @@
   (should (eq 'cons
               (type-of anju-buffer-list-filter-functions)))
 
-  (let* ((tests '(anju-buffer-list-plain-filter
+  (let* ((tests '(anju-buffer-list-project-filter
                   anju-buffer-list-compilation-filter
                   anju-buffer-list-grep-filter
                   anju-buffer-list-xref-filter


### PR DESCRIPTION
This changes the behavior of the pop-up menu raised when the name of the buffer
in the mode line is clicked.

The value of `anju-buffer-list-filter-functions` is changed to include the new
filter `anju-buffer-list-project-filter` in place of
`anju-buffer-list-plain-filter`.
