### PR TITLE
Add org-capture and org-agenda to Tools menu

### DIFF
--- a/lisp/anju-main-menu.el
+++ b/lisp/anju-main-menu.el
@@ -545,28 +545,25 @@ Auto rescan `imenu-auto-rescan' is enabled for all affected modes."
     '(menu-item "--")
     'Macro\ Recorder)
 
-  ;; TODO: Consider having a variable to control this.
+  (easy-menu-add-item global-map '(menu-bar tools)
+                      [org-capture
+                       org-capture
+                       :label "Org Capture…"
+                       :help "Capture something"]
+                      'grep)
 
-  ;; (easy-menu-add-item global-map '(menu-bar tools)
-  ;;                       [org-capture
-  ;;                        org-capture
-  ;;                        :label "Org Capture…"
-  ;;                        :help "Capture something"]
-  ;;                       'grep)
+  (easy-menu-add-item global-map '(menu-bar tools)
+                      [org-agenda
+                       org-agenda
+                       :label "Org Agenda…"
+                       :help "Dispatch agenda commands to collect entries to \
+  the agenda buffer"]
+                      'grep)
 
-  ;;   (easy-menu-add-item global-map '(menu-bar tools)
-  ;;                       [org-agenda
-  ;;                        org-agenda
-  ;;                        :label "Org Agenda…"
-  ;;                        :help "Dispatch agenda commands to collect entries to \
-  ;; the agenda buffer"]
-  ;;                       'grep)
-
-  ;;   (keymap-set-after (lookup-key global-map [menu-bar tools])
-  ;;     "<separator-tools-org>"
-  ;;     '(menu-item "--")
-  ;;     #'org-agenda)
-  )
+  (keymap-set-after (lookup-key global-map [menu-bar tools])
+    "<separator-tools-org>"
+    '(menu-item "--")
+    #'org-agenda))
 
 (provide 'anju-main-menu)
 ;;; anju-main-menu.el ends here

--- a/lisp/anju-utils.el
+++ b/lisp/anju-utils.el
@@ -121,6 +121,7 @@ at the front of the list.
 
 Anju provides the following buffer filters:
 
+- `anju-buffer-list-project-filter'
 - `anju-buffer-list-plain-filter'
 - `anju-buffer-list-compilation-filter'
 - `anju-buffer-list-grep-filter'
@@ -135,7 +136,8 @@ add their own filters to define the resulting buffer list returned by
 `anju-buffer-list-menu-items'."
 
   :type '(alist
-          :key-type (choice (function-item anju-buffer-list-plain-filter)
+          :key-type (choice (function-item anju-buffer-list-project-filter)
+                            (function-item anju-buffer-list-plain-filter)
                             (function-item anju-buffer-list-compilation-filter)
                             (function-item anju-buffer-list-grep-filter)
                             (function-item anju-buffer-list-xref-filter)

--- a/tests/test-anju-main-menu.el
+++ b/tests/test-anju-main-menu.el
@@ -630,8 +630,18 @@ leaving just one")
 (ert-deftest test-anju-main-menu--reconfigure-tools ()
   (anju-main-menu--reconfigure-tools)
 
-  (let ((macro-menu (easy-menu-get-map global-map '(menu-bar tools Macro\ Recorder))))
-    (test--anju-kmacro-menu macro-menu)))
+  (let* ((tools (easy-menu-get-map global-map '(menu-bar tools)))
+         (macro-menu (easy-menu-get-map tools '(Macro\ Recorder)))
+         (macro-sep (easy-menu-get-map tools '(separator-tools-kmacro)))
+         (org-capture-item (easy-menu-get-map tools '(org-capture)))
+         (org-agenda-item (easy-menu-get-map tools '(org-agenda)))
+         (org-sep (easy-menu-get-map tools '(separator-tools-org))))
+
+    (test--anju-kmacro-menu macro-menu)
+    (should macro-sep)
+    (should org-capture-item)
+    (should org-agenda-item)
+    (should org-sep)))
 
 
 (provide 'test-anju-main-menu)


### PR DESCRIPTION
* lisp/anju-main-menu.el (anju-main-menu--reconfigure-tools):
  - Add org-capture and org-agenda

* lisp/anju-utils.el (anju-buffer-list-filter-functions):
  - Add fixes for anju-buffer-list-project-filter.
