### PR TITLE
Merge development to main 20260609_145530

### DIFF
--- a/docs/anju.org
+++ b/docs/anju.org
@@ -713,21 +713,20 @@ Anju provides optional support for Magit 4.4+.
 #+VINDEX: context-menu-mode
 #+VINDEX: anju-init
 
-Basic installation of Anju composes of two parts:
+To install Anju, add the command ~anju-init~ to your Emacs initialization file.
 
-1. Turn on ~context-menu-mode~ to major modes of preference. This is done using the ~add-hook~ function as shown below.
-  #+begin_src elisp :lexical no
-    (add-hook 'prog-mode-hook #'context-menu-mode)
-    (add-hook 'text-mode-hook #'context-menu-mode)
-    (add-hook 'dired-mode-hook #'context-menu-mode)
-    (add-hook 'shell-mode-hook #'context-menu-mode)
-  #+end_src
+#+begin_src elisp :lexical no
+  (anju-init)
+#+end_src
 
-2. Call ~anju-init~ in your Emacs initialization file.
+This command will initialize ~context-menu-mode~ and reconfigure the following mouse menus and bindings:
 
-  #+begin_src elisp :lexical no
-    (anju-init)
-  #+end_src
+- Legacy mouse bindings
+- Mode line bindings
+- Main menu
+- Context menus for different modes
+
+The ~anju-init~ command can also be invoked via ~M-x~.
 
 Anju supports a high degree of customization. Users who wish this should make a deep read of the [[#customization][Customization]] section.
 

--- a/docs/anju.org
+++ b/docs/anju.org
@@ -6,7 +6,7 @@
 #+EMAIL: kickingvegas@gmail.com
 #+OPTIONS: ':t toc:t author:t email:t H:4 f:t
 #+LANGUAGE: en
-#+MACRO: version 1.5.0
+#+MACRO: version 1.5.1-rc.1
 #+MACRO: kbd (eval (org-texinfo-kbd-macro $1))
 #+TEXINFO_FILENAME: anju.info
 #+TEXINFO_CLASS: casual

--- a/docs/anju.texi
+++ b/docs/anju.texi
@@ -50,11 +50,11 @@ Support direct manipulation when possible
 Re-organization of the menu bar
 @end itemize
 
-The features offered by Anju are opinionated, but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
+The features offered by Anju are opinionated@comma{} but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
 
 Please note that all UI terminology in this document is Emacs-centric and differs from conventional GUI terminology. Refer to (emacs) Frames (@ref{Frames,emacs#Frames,,emacs,}) for more detail on this.
 
-It costs money to make, enhance, and maintain Anju as ideologically free software. If you enjoy using Anju, please buy me a coffee to help support its development and maintenance.
+It costs money to make@comma{} enhance@comma{} and maintain Anju as ideologically free software. If you enjoy using Anju@comma{} please buy me a coffee to help support its development and maintenance.
 
 @image{images/default-yellow,,,,png}
 
@@ -177,7 +177,7 @@ Lengthy menus that feel more like an inventory of commands rather than a designe
 Over-reliance on mouse workflows that require switching between the mouse and keyboard.
 @end itemize
 
-Anju makes opinionated design decisions, but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
+Anju makes opinionated design decisions@comma{} but avoids unconventional behavior. Anju aspires to bring a calmer mouse experience to Emacs.
 
 Elaboration on what informs Anju's opinions is described below.
 
@@ -192,7 +192,7 @@ Elaboration on what informs Anju's opinions is described below.
 
 This section conveys the principles and concerns used by Anju to inform its design decisions.
 
-Editorially, all design decisions for Anju are ultimately the opinion of Charles Y@. Choi.
+Editorially@comma{} all design decisions for Anju are ultimately the opinion of Charles Y@. Choi.
 
 
 @subheading General Principles
@@ -207,18 +207,18 @@ A coherent information architecture should be conveyed.
 Balance between concision and discoverability should be made in a menu's offerings.
 @end itemize
 @item
-Nesting of sub-menus should be carefully considered, ideally not exceeding a depth of two.
+Nesting of sub-menus should be carefully considered@comma{} ideally not exceeding a depth of two.
 @item
 Mouse workflows that require keyboard input should be minimized.
 @item
-If the opportunity to provide a direct manipulation experience is available, it should be taken.
+If the opportunity to provide a direct manipulation experience is available@comma{} it should be taken.
 @item
 Unconventional mouse interactions should be avoided.
 @end itemize
 
 @subheading Concerns
 
-Anju takes the position that different types of menus have different concerns or objectives. This is most apparent in contrasting the design of a main menu section (e.g. File, Edit, Options, …) to that of a context menu.
+Anju takes the position that different types of menus have different concerns or objectives. This is most apparent in contrasting the design of a main menu section (e.g. File@comma{} Edit@comma{} Options@comma{} …) to that of a context menu.
 
 For Anju:
 
@@ -229,7 +229,7 @@ The highest concern of a main menu section is discoverability.
 The highest concern of a context menu is concision.
 @end itemize
 
-A common implementation practice in Emacs is to reuse menu keymaps for both the main menu and context menus. This violates the above concerns, which Anju seeks to address.
+A common implementation practice in Emacs is to reuse menu keymaps for both the main menu and context menus. This violates the above concerns@comma{} which Anju seeks to address.
 
 The next sub-sections further detail the design concerns with respect to an area where mouse interaction occurs.
 
@@ -254,11 +254,11 @@ Anju takes the opinion that context menus should @emph{not} support general comm
 
 @subsubheading Direct Manipulation
 
-Support for direct action based on mouse cursor position is a common user interaction technique. Anju applies this to Emacs window management, where window creation, deletion, and swapping are supported from both the context menu and the mode line.
+Support for direct action based on mouse cursor position is a common user interaction technique. Anju applies this to Emacs window management@comma{} where window creation@comma{} deletion@comma{} and swapping are supported from both the context menu and the mode line.
 
 @subsubheading No Middle Button Bindings
 
-Anju eschews Emacs' default middle mouse button bindings as they presume usage of a @uref{https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Sun_optical_mouse.jpg/960px-Sun_optical_mouse.jpg, 90's style 3-button mouse}. This style of mouse design has long been superseded with a middle @uref{https://upload.wikimedia.org/wikipedia/commons/2/22/3-Tasten-Maus_Microsoft.jpg, scroll-wheel+button control}. This widespread hardware change has resulted in the majority of mouse-supporting applications to emphasize scrolling actions with the middle control and clicking actions to the left and right buttons. Anju follows suit, primarily binding the right mouse button click (down) event to raising a context menu. In addition, Anju reconfigures commands that were previously bound to the middle button to ones accessible via a context menu.
+Anju eschews Emacs' default middle mouse button bindings as they presume usage of a @uref{https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Sun_optical_mouse.jpg/960px-Sun_optical_mouse.jpg, 90's style 3-button mouse}. This style of mouse design has long been superseded with a middle @uref{https://upload.wikimedia.org/wikipedia/commons/2/22/3-Tasten-Maus_Microsoft.jpg, scroll-wheel+button control}. This widespread hardware change has resulted in the majority of mouse-supporting applications to emphasize scrolling actions with the middle control and clicking actions to the left and right buttons. Anju follows suit@comma{} primarily binding the right mouse button click (down) event to raising a context menu. In addition@comma{} Anju reconfigures commands that were previously bound to the middle button to ones accessible via a context menu.
 
 The only exception Anju makes in this matter is to keep the Emacs default binding of @code{mouse-2} to @code{mouse-yank-primary}.
 
@@ -286,7 +286,7 @@ The following mode line enhancements are provided by Anju:
 @subheading Pop-up Buffer List
 @cindex Pop-up Buffer List
 
-On the mode line, left-click (@code{mouse-1}) on the buffer name to raise a pop-up menu containing a list of open buffers. The contents of this list is controlled by the customizable variable @code{anju-buffer-list-filter-functions}. More info on customizing the buffer list menu can be found in @ref{Mode Line Buffer List Menu Customization}.
+On the mode line@comma{} left-click (@code{mouse-1}) on the buffer name to raise a pop-up menu containing a list of open buffers. The contents of this list is controlled by the customizable variable @code{anju-buffer-list-filter-functions}. More info on customizing the buffer list menu can be found in @ref{Mode Line Buffer List Menu Customization, , Mode Line Buffer List Menu Customization}.
 
 
 @image{images/anju-mode-line-buffer-list,,,,png}
@@ -298,7 +298,7 @@ A right-click (@code{mouse-3}) on any blank space on the mode line will pop-up a
 
 @image{images/anju-mode-line-window-management,,,,png}
 
-From here, one can:
+From here@comma{} one can:
 @itemize
 @item
 Delete the window (×)
@@ -307,7 +307,7 @@ Split the window horizontally (→)
 @item
 Split the window vertically (↓)
 @item
-If multiple windows are shown, swap the current window.
+If multiple windows are shown@comma{} swap the current window.
 @end itemize
 
 Note: usage of ``window'' refers to the Emacs definition of it. Refer to @ref{Frames,,,emacs,} for more detail on this.
@@ -315,7 +315,7 @@ Note: usage of ``window'' refers to the Emacs definition of it. Refer to @ref{Fr
 @subheading Toggle Maximize Window
 @cindex Toggle Maximize Window
 
-A left-double-click on any blank space on the mode line will checkpoint the current window configuration, then maximize the current window (@code{delete-other-windows}). Re-doing the left-double-click will restore the prior window configuration.
+A left-double-click on any blank space on the mode line will checkpoint the current window configuration@comma{} then maximize the current window (@code{delete-other-windows}). Re-doing the left-double-click will restore the prior window configuration.
 
 @node Context Menu Features
 @section Context Menu Features
@@ -350,10 +350,10 @@ Version-controlled source
 @item
 Window management
 @item
-Full support for @code{context-menu-mode} customization (See @ref{Context Menu Customization}).
+Full support for @code{context-menu-mode} customization (See @ref{Context Menu Customization, , Context Menu Customization}).
 @end itemize
 
-Anju deliberately omits the display of the default mode-specific menu keymaps in the context menu as they are considered redundant to their display in the main menu. Rationale for this is described in @ref{Design Principles and Concerns}. Users can still access the default mode-specific menu keymap by using the binding @kbd{C-<mouse-3>}.
+Anju deliberately omits the display of the default mode-specific menu keymaps in the context menu as they are considered redundant to their display in the main menu. Rationale for this is described in @ref{Design Principles and Concerns, , Design Principles and Concerns}. Users can still access the default mode-specific menu keymap by using the binding @kbd{C-<mouse-3>}.
 
 Learn more about the different areas Anju enhances context menus in the links below.
 
@@ -376,21 +376,21 @@ Learn more about the different areas Anju enhances context menus in the links be
 
 @image{images/anju-context-menu-region,,,,png}
 
-If a context menu is raised on selected text, the following menu items are displayed:
+If a context menu is raised on selected text@comma{} the following menu items are displayed:
 
 @table @asis
 @item Occur
 Run @code{occur} command to show occurrences of selected text.
 
 @item Style
-Applies mode-specific markup to emphasize the selected text (e.g. bold, italic, code, etc.).
+Applies mode-specific markup to emphasize the selected text (e.g. bold@comma{} italic@comma{} code@comma{} etc.).
 @itemize
 @item
 Available only for @code{org-mode} and @code{markdown-mode}.
 @end itemize
 
 @item Transform Text
-Applies transforms (upper/lower case, capitalize) to the selected text.
+Applies transforms (upper/lower case@comma{} capitalize) to the selected text.
 
 @item Query Replace
 Run @code{query-replace} on selected text.
@@ -409,10 +409,10 @@ Available only on modes derived from @code{prog-mode} and @code{org-mode}
 Writes selected text to a user-specified file.
 
 @item Look Up
-If a word is selected, uses @code{dictionary} to look up its definition.
+If a word is selected@comma{} uses @code{dictionary} to look up its definition.
 
 @item Copy as…
-If the current buffer is using Org mode, then this sub-menu is displayed. Learn more about this in @ref{Org “Copy as…” Context Menu}.
+If the current buffer is using Org mode@comma{} then this sub-menu is displayed. Learn more about this in @ref{Org “Copy as…” Context Menu, , Org “Copy as…” Context Menu}.
 @end table
 
 @node Org Mode Context Menu
@@ -431,9 +431,9 @@ Item
 Table
 @end itemize
 
-In addition if text is selected, then support for styling, linking, and copying as a different format are supported.
+In addition if text is selected@comma{} then support for styling@comma{} linking@comma{} and copying as a different format are supported.
 
-Note that the Org mode context menu is deliberately restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns}.
+Note that the Org mode context menu is deliberately restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns, , Design Principles and Concerns}.
 
 It is recommended that the @code{org-mouse} package be loaded when using Anju.
 
@@ -452,7 +452,7 @@ It is recommended that the @code{org-mouse} package be loaded when using Anju.
 
 @cindex Org Headline Context Menu
 
-If the context menu is raised on a headline, then commands related to TODO state, change to body, clocking, sorting, and promotion are offered.
+If the context menu is raised on a headline@comma{} then commands related to TODO state@comma{} change to body@comma{} clocking@comma{} sorting@comma{} and promotion are offered.
 
 @image{images/anju-context-menu-org-headline,,,,png}
 
@@ -461,9 +461,9 @@ If the context menu is raised on a headline, then commands related to TODO state
 
 @cindex Org Item Context Menu
 
-If the context menu is raised on a list item, then commands related to sorting, cycling bullet-style, promotion and checkbox operations are provided.
+If the context menu is raised on a list item@comma{} then commands related to sorting@comma{} cycling bullet-style@comma{} promotion and checkbox operations are provided.
 
-The menu item ``Change to Checkbox'' will convert an item to a checkbox, with the additional behavior that if the point is at the start of the whole list, the whole list will be converted.
+The menu item ``Change to Checkbox'' will convert an item to a checkbox@comma{} with the additional behavior that if the point is at the start of the whole list@comma{} the whole list will be converted.
 
 @image{images/anju-context-menu-org-item,,,,png}
 
@@ -478,15 +478,15 @@ Note that checkboxes in screenshots are prettified using @code{prettify-symbols-
 
 @cindex Org Table Context Menu
 
-If the context menu is raised in a table, then table-specific commands are shown.
+If the context menu is raised in a table@comma{} then table-specific commands are shown.
 
 @image{images/anju-context-menu-org-table,,,,png}
 
 The context menu shows the current Org table cell reference where the point is in (e.g. @code{@@3$2}). Clicking on this reference will copy it to the @code{kill-ring} for subsequent use in a table formula.
 
-If a selected region or rectangle is made whose extents are within the table, then the table region reference  is displayed.
+If a selected region or rectangle is made whose extents are within the table@comma{} then the table region reference  is displayed.
 
-The “Org Table Region” sub-menu provides commands to cut, copy, and paste rectangular regions made in the table. Note that the binding @kbd{C-M-<mouse-1>} lets you make rectangle selections.
+The “Org Table Region” sub-menu provides commands to cut@comma{} copy@comma{} and paste rectangular regions made in the table. Note that the binding @kbd{C-M-<mouse-1>} lets you make rectangle selections.
 
 @node Org Insert Link
 @subsubsection Org Insert Link
@@ -495,9 +495,9 @@ The “Org Table Region” sub-menu provides commands to cut, copy, and paste re
 
 @image{images/anju-context-menu-org-link,,,,png}
 
-If the point is on selected text or an existing Org link, the context menu will have the menu item “Link…” to run the command @code{org-insert-link}. From there you can add or edit a link.
+If the point is on selected text or an existing Org link@comma{} the context menu will have the menu item “Link…” to run the command @code{org-insert-link}. From there you can add or edit a link.
 
-If an Org link has already been stored, then the menu item “Paste Last Org Link” will be displayed. See more at @ref{Org Paste Context Menu}.
+If an Org link has already been stored@comma{} then the menu item “Paste Last Org Link” will be displayed. See more at @ref{Org Paste Context Menu, , Org Paste Context Menu}.
 
 @node Org Toggle Images & Show Markup
 @subsubsection Org Toggle Images & Show Markup
@@ -523,11 +523,11 @@ Reveal or hide display of Org markup.
 
 @image{images/anju-context-menu-org-copy-as,,,,png}
 
-If text is selected, the “Copy as…” sub-menu will be presented. This sub-menu will provide different format options to export the selected text to the system clipboard for subsequent pasting. The following formats are supported.
+If text is selected@comma{} the “Copy as…” sub-menu will be presented. This sub-menu will provide different format options to export the selected text to the system clipboard for subsequent pasting. The following formats are supported.
 
 @itemize
 @item
-GFM  (GitHub Flavored Markdown, only available if the @code{ox-gfm} (@uref{https://melpa.org/#/ox-gfm, MELPA}) package is installed)
+GFM  (GitHub Flavored Markdown@comma{} only available if the @code{ox-gfm} (@uref{https://melpa.org/#/ox-gfm, MELPA}) package is installed)
 @item
 Markdown
 @item
@@ -544,7 +544,7 @@ RTF (only available on macOS)
 
 Users who frequently work with other text-based formats may find this menu useful.
 
-Markdown users may find the companion feature of “Paste Markdown as Org” also useful (@ref{Org Paste Context Menu}).
+Markdown users may find the companion feature of “Paste Markdown as Org” also useful (@ref{Org Paste Context Menu, , Org Paste Context Menu}).
 
 @node Org Paste Context Menu
 @subsubsection Org Paste Context Menu
@@ -557,13 +557,13 @@ Anju adds more “Paste” commands that will display given the right context.
 
 @table @asis
 @item Paste Last Org Link
-If it exists, this command will insert the last stored Org link.
+If it exists@comma{} this command will insert the last stored Org link.
 
 @item Paste Markdown as Org
-If the clipboard (latest yank) is known by the user to be Markdown text, this command will convert the clipboard text to Org via @code{pandoc}, then paste (yank) it into the buffer.
+If the clipboard (latest yank) is known by the user to be Markdown text@comma{} this command will convert the clipboard text to Org via @code{pandoc}@comma{} then paste (yank) it into the buffer.
 
 @item Paste Media
-If an image as been copied into the clipboard, this menu item will ``paste'' it via the @code{yank-media} command.
+If an image as been copied into the clipboard@comma{} this menu item will ``paste'' it via the @code{yank-media} command.
 @end table
 
 @node Dired Mode Context Menu
@@ -575,11 +575,11 @@ Anju enhances the context menu support for Dired mode. The screenshot below show
 
 @image{images/anju-context-menu-dired-copy-to,,,,png}
 
-If the mouse point is over a directory, the option to insert a view (aka subdir) for it in the buffer is provided.
+If the mouse point is over a directory@comma{} the option to insert a view (aka subdir) for it in the buffer is provided.
 
 @image{images/anju-context-menu-dired-insert-subdir,,,,png}
 
-Note that the Dired context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns}.
+Note that the Dired context menu is intentionally restrained in its command offering in accord with Anju's @ref{Design Principles and Concerns, , Design Principles and Concerns}.
 
 @node Info Context Menu
 @subsection Info Context Menu
@@ -609,11 +609,11 @@ Anju enhances the context menu for Emacs Lisp (Elisp) development with support f
 
 @cindex Basic Elisp Context Menu
 
-Anju enhances the default Elisp context menu by providing commands for evaluating, debugging, and refactoring Elisp. Many of these commands are context-sensitive to point location. If a command does not apply at point, it will not be shown in the context menu.
+Anju enhances the default Elisp context menu by providing commands for evaluating@comma{} debugging@comma{} and refactoring Elisp. Many of these commands are context-sensitive to point location. If a command does not apply at point@comma{} it will not be shown in the context menu.
 
-If hideshow (@ref{Hideshow,,,emacs,}) support is enabled, then a sub-menu “Hide/Show” is provided.
+If hideshow (@ref{Hideshow,,,emacs,}) support is enabled@comma{} then a sub-menu “Hide/Show” is provided.
 
-The screenshot below shows the context menu raised when the point is on the function @code{foo}. Selecting the menu item “Edebug “foo”” will instrument @code{foo} for debugging. On the next invocation of @code{foo}, the Edebug debugger will be run. Anju enhances the @ref{Edebug Mode Context Menu, , context menu for Edebug} as well.
+The screenshot below shows the context menu raised when the point is on the function @code{foo}. Selecting the menu item “Edebug “foo”” will instrument @code{foo} for debugging. On the next invocation of @code{foo}@comma{} the Edebug debugger will be run. Anju enhances the @ref{Edebug Mode Context Menu, , context menu for Edebug} as well.
 
 @image{images/anju-context-menu-elisp,,,,png}
 
@@ -626,13 +626,13 @@ Note that the Emacs default context menu for Elisp supports Xref (@ref{Xref,,,em
 
 @cindex Edebug Mode Context Menu
 
-When debugging Elisp using Edebug, the following context menu offering its many commands is shown.
+When debugging Elisp using Edebug@comma{} the following context menu offering its many commands is shown.
 
 @image{images/anju-context-menu-edebug,,,,png}
 
-For users new to Edebug, it is helpful to understand that code execution is sexp-based as opposed to line/function-based in other IDEs.
+For users new to Edebug@comma{} it is helpful to understand that code execution is sexp-based as opposed to line/function-based in other IDEs.
 
-To better understand Edebug's command set, a close reading of its manual is recommended (@ref{Edebug,,,elisp,}).
+To better understand Edebug's command set@comma{} a close reading of its manual is recommended (@ref{Edebug,,,elisp,}).
 
 @node ERT Support
 @subsubsection ERT Support
@@ -676,9 +676,9 @@ The @code{*add-two*} buffer can be edited as needed and its contents placed into
 @image{images/anju-context-menu-compilation,,,,png}
 
 
-If the buffer is the output of a compilation, then its context menu is populated with commands to either recompile or invoke a new compile command.
+If the buffer is the output of a compilation@comma{} then its context menu is populated with commands to either recompile or invoke a new compile command.
 
-If the buffer is the output of a Grep search, then its context menu is populated with the command to refresh the search.
+If the buffer is the output of a Grep search@comma{} then its context menu is populated with the command to refresh the search.
 
 @node Makefile Context Menu
 @subsection Makefile Context Menu
@@ -697,9 +697,9 @@ This context menu offers commands provided by Makefile mode.
 
 @image{images/anju-context-menu-rectangle,,,,png}
 
-If a rectangle selection is made (@kbd{C-M-<mouse-1>}) or has been killed, then the “Rectangle” sub-menu is presented in the context menu. Anju treats a rectangle selection with the highest priority; most Anju context menus will @emph{not} display if a rectangle selection is made.
+If a rectangle selection is made (@kbd{C-M-<mouse-1>}) or has been killed@comma{} then the “Rectangle” sub-menu is presented in the context menu. Anju treats a rectangle selection with the highest priority; most Anju context menus will @emph{not} display if a rectangle selection is made.
 
-To learn more about rectangle commands, see @ref{Rectangles,info ``(emacs) Rectangles'',,emacs,}.
+To learn more about rectangle commands@comma{} see @ref{Rectangles,info ``(emacs) Rectangles'',,emacs,}.
 
 @node Version-Controlled Source
 @subsection Version-Controlled Source
@@ -709,16 +709,16 @@ To learn more about rectangle commands, see @ref{Rectangles,info ``(emacs) Recta
 
 @image{images/anju-context-menu-vc,,,,png}
 
-If a context menu is raised on a buffer containing a modified version controlled file, then support for viewing the difference between the modifications with its previous commit is provided by the menu item “Ediff revision…”.
+If a context menu is raised on a buffer containing a modified version controlled file@comma{} then support for viewing the difference between the modifications with its previous commit is provided by the menu item “Ediff revision…”.
 
-If Magit 4.4+ is installed, then different Magit commands depending on context are displayed. If the context menu is raised in a file buffer, then the menu item ``Magit Dispatch…'' (@code{magit-file-dispatch}) is shown, otherwise ``Magit Status'' (@code{magit-status}).
+If Magit 4.4+ is installed@comma{} then different Magit commands depending on context are displayed. If the context menu is raised in a file buffer@comma{} then the menu item ``Magit Dispatch…'' (@code{magit-file-dispatch}) is shown@comma{} otherwise ``Magit Status'' (@code{magit-status}).
 
 @node Main Menu Features
 @section Main Menu Features
 
 @cindex Main Menu Features
 
-Anju enhances the menu bar of Emacs by making opinionated changes to its existing menus as well as adding several new ones. These changes are configurable per menu in the main menu (e.g. ``File'', ``Edit'', ``Options'', etc.). For more detail, see @ref{Main Menu Customization}.
+Anju enhances the menu bar of Emacs by making opinionated changes to its existing menus as well as adding several new ones. These changes are configurable per menu in the main menu (e.g. ``File''@comma{} ``Edit''@comma{} ``Options''@comma{} etc.). For more detail@comma{} see @ref{Main Menu Customization, , Main Menu Customization}.
 
 @menu
 * File Menu Features::
@@ -747,9 +747,9 @@ Updates the “New Frame on Display Server@dots{}” menu item to only display o
 Updates the “New Frame on Monitor…” menu item to only display if more than one monitor is detected.
 @end itemize
 
-For the macOS NS variant of Emacs, the above update to “New Frame on Monitor…” will only work on Emacs version 31+.
+For the macOS NS variant of Emacs@comma{} the above update to “New Frame on Monitor…” will only work on Emacs version 31+.
 
-These modifications are optional. For more detail, see @ref{File Menu Customization}.
+These modifications are optional. For more detail@comma{} see @ref{File Menu Customization, , File Menu Customization}.
 
 @node Edit Menu Features
 @subsection Edit Menu Features
@@ -789,7 +789,7 @@ Adds the menu item “Align Regexp…”.
 Adds the menu item “Duplicate”.
 @end itemize
 
-On the macOS NS variant of Emacs, the following menu items are added.
+On the macOS NS variant of Emacs@comma{} the following menu items are added.
 
 @itemize
 @item
@@ -917,16 +917,16 @@ Emoji & Symbols (@code{ns-do-show-character-palette}) (only on macOS NS)
 
 Note that a menu command can be run again immediately after it has been issued using the @code{repeat} command (binding @kbd{C-x z}). This is useful when using the move text commands.
 
-These modifications are optional. For more detail, see @ref{Edit Menu Customization}.
+These modifications are optional. For more detail@comma{} see @ref{Edit Menu Customization, , Edit Menu Customization}.
 
 @node Options Menu Features
 @subsection Options Menu Features
 
 @cindex Options Menu Features
 
-Anju makes the presumption that most Emacs users do not use the CUA mode configuration in the menu bar @strong{Options} menu. As such, the “Cut/Paste with C-x/C-c/C-v (CUA Mode)” menu item is removed.
+Anju makes the presumption that most Emacs users do not use the CUA mode configuration in the menu bar @strong{Options} menu. As such@comma{} the “Cut/Paste with C-x/C-c/C-v (CUA Mode)” menu item is removed.
 
-This modification is optional. For more detail, see @ref{Options Menu Customization}.
+This modification is optional. For more detail@comma{} see @ref{Options Menu Customization, , Options Menu Customization}.
 
 @node Bookmarks Menu Features
 @subsection Bookmarks Menu Features
@@ -937,7 +937,7 @@ Anju adds a @strong{Bookmarks} menu to the main menu to work with Emacs-specific
 
 @image{images/anju-main-menu-bookmarks,,,,png}
 
-This modification is optional. For more detail, see @ref{Bookmarks Menu Customization}.
+This modification is optional. For more detail@comma{} see @ref{Bookmarks Menu Customization, , Bookmarks Menu Customization}.
 
 The menu hierarchy of the @strong{Bookmarks} menu is described below with the actual command shown in parenthesis next to its label.
 
@@ -957,7 +957,7 @@ Jump to Bookmark… (@code{bookmark-jump})
 
 @image{images/anju-main-menu-text,,,,png}
 
-If the major mode of the current buffer is derived from @code{text-mode}, then a @strong{Text} menu is displayed in the menu bar.
+If the major mode of the current buffer is derived from @code{text-mode}@comma{} then a @strong{Text} menu is displayed in the menu bar.
 
 The menu hierarchy of the @strong{Text} menu is described below with the actual command shown in parenthesis next to its label.
 
@@ -1024,7 +1024,7 @@ Auto Fill (@code{toggle-text-mode-auto-fill})
 
 Note the @strong{Style} menu is visible only for Org and Markdown modes.
 
-This modification is optional. For more detail, see @ref{Text Menu Customization}.
+This modification is optional. For more detail@comma{} see @ref{Text Menu Customization, , Text Menu Customization}.
 
 @node Index Menu (imenu) Features
 @subsection Index Menu (imenu) Features
@@ -1034,7 +1034,7 @@ This modification is optional. For more detail, see @ref{Text Menu Customization
 @image{images/anju-main-menu-imenu,,,,png}
 
 
-For certain modes that support Imenu (@ref{Imenu,,,emacs,}), Anju will add an @strong{Index} menu to the menu bar via the function  @code{imenu-add-menubar-index}.
+For certain modes that support Imenu (@ref{Imenu,,,emacs,})@comma{} Anju will add an @strong{Index} menu to the menu bar via the function  @code{imenu-add-menubar-index}.
 
 Modes supported this way by Anju are:
 
@@ -1049,7 +1049,7 @@ Modes supported this way by Anju are:
 @code{makefile-mode}
 @end itemize
 
-This modification is optional. For more detail, see @ref{Imenu Menu Customization}.
+This modification is optional. For more detail@comma{} see @ref{Imenu Menu Customization, , Imenu Menu Customization}.
 
 @node Tools Menu Features
 @subsection Tools Menu Features
@@ -1063,7 +1063,7 @@ Anju makes the following modifications to the menu bar @strong{Tools} menu:
 
 @table @asis
 @item Adds the “Macro Recorder” sub-menu
-Commands to create, run, edit, and debug  @ref{Macro Recorder Menu, , keyboard macros}.
+Commands to create@comma{} run@comma{} edit@comma{} and debug  @ref{Macro Recorder Menu, , keyboard macros}.
 
 @item Adds global Org commands
 Provide general access to these commands
@@ -1094,20 +1094,20 @@ Keyboard macros offer workflow automation in Emacs in a ``no-code'' fashion.  An
 
 Note that both keystroke and mouse menu actions can be recorded by a keyboard macro.
 
-For more reading on keyboard macros, see @ref{Keyboard Macros,,,emacs,}.
+For more reading on keyboard macros@comma{} see @ref{Keyboard Macros,,,emacs,}.
 
 @node Help Menu Features
 @subsection Help Menu Features
 
 @cindex Help Menu Features
 
-Anju re-organizes the @strong{Help} menu as shown below. The re-organization emphasizes showing documentation in a new frame, takes out non-help related menu items, and offers more concision.
+Anju re-organizes the @strong{Help} menu as shown below. The re-organization emphasizes showing documentation in a new frame@comma{} takes out non-help related menu items@comma{} and offers more concision.
 
 @image{images/anju-main-menu-help,,,,png}
 
-This modification is optional. For more detail, see @ref{Help Menu Customization}.
+This modification is optional. For more detail@comma{} see @ref{Help Menu Customization, , Help Menu Customization}.
 
-For experienced users, the ``Emacs Tutorial'' menu items can be removed via the customizable variable @code{anju-help-menu-remove-emacs-tutorial}.
+For experienced users@comma{} the ``Emacs Tutorial'' menu items can be removed via the customizable variable @code{anju-help-menu-remove-emacs-tutorial}.
 
 @node Window Management Features
 @section Window Management Features
@@ -1121,7 +1121,7 @@ Window management via mouse interaction is provided for through the @ref{Mode Li
 
 @cindex Requirements
 
-Anju requires Emacs 29.1+, Casual 2.13+, Markdown Mode 2.7+.
+Anju requires Emacs 29.1+@comma{} Casual 2.13+@comma{} Markdown Mode 2.7+.
 
 Certain menus require more installed software:
 
@@ -1141,29 +1141,30 @@ Anju provides optional support for Magit 4.4+.
 @vindex context-menu-mode
 @vindex anju-init
 
-Basic installation of Anju composes of two parts:
-
-@enumerate
-@item
-Turn on @code{context-menu-mode} to major modes of preference. This is done using the @code{add-hook} function as shown below.
-@lisp
-(add-hook 'prog-mode-hook #'context-menu-mode)
-(add-hook 'text-mode-hook #'context-menu-mode)
-(add-hook 'dired-mode-hook #'context-menu-mode)
-(add-hook 'shell-mode-hook #'context-menu-mode)
-@end lisp
-
-@item
-Call @code{anju-init} in your Emacs initialization file.
+To install Anju@comma{} add the command @code{anju-init} to your Emacs initialization file.
 
 @lisp
 (anju-init)
 @end lisp
-@end enumerate
 
-Anju supports a high degree of customization. Users who wish this should make a deep read of the @ref{Customization} section.
+This command will initialize @code{context-menu-mode} and reconfigure the following mouse menus and bindings:
 
-While not required, the following additions to your Emacs initialization file can further enhance your mouse experience:
+@itemize
+@item
+Legacy mouse bindings
+@item
+Mode line bindings
+@item
+Main menu
+@item
+Context menu
+@end itemize
+
+The @code{anju-init} command can also be invoked via @code{M-x}.
+
+Anju supports a high degree of customization. Users who wish this should make a deep read of the @ref{Customization, , Customization} section.
+
+While not required@comma{} the following additions to your Emacs initialization file can further enhance your mouse experience:
 
 @itemize
 @item
@@ -1176,7 +1177,7 @@ Enable @code{org-mouse}
 Add Markdown export support to Org mode
 @itemize
 @item
-@code{M-x} @code{customize-variable} @code{org-export-backends}, check @code{md} option.
+@code{M-x} @code{customize-variable} @code{org-export-backends}@comma{} check @code{md} option.
 @end itemize
 
 @item
@@ -1187,7 +1188,7 @@ Globally bind @code{C-x 1} to @code{anju-toggle-one-window}.
 @end lisp
 
 @item
-Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog interactions, or @code{nil} to always get a mini-buffer prompt.
+Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog interactions@comma{} or @code{nil} to always get a mini-buffer prompt.
 @end itemize
 
 @node Customization
@@ -1195,7 +1196,7 @@ Set @code{use-file-dialog} to @code{t} to support mouse-driven-only dialog inter
 
 @cindex Customization
 
-Anju provides a number of ways to customize mouse interactions in Emacs. In many cases, Anju leverages off existing Emacs customization options, particularly around defining and modifying menus. Users who wish to modify menus in Emacs should familiarize themselves with menu keymaps (@ref{Menu Keymaps,,,elisp,}) and the Easy Menu (@ref{Easy Menu,,,elisp,}) library.
+Anju provides a number of ways to customize mouse interactions in Emacs. In many cases@comma{} Anju leverages off existing Emacs customization options@comma{} particularly around defining and modifying menus. Users who wish to modify menus in Emacs should familiarize themselves with menu keymaps (@ref{Menu Keymaps,,,elisp,}) and the Easy Menu (@ref{Easy Menu,,,elisp,}) library.
 
 Customization options for the different areas Anju covers are detailed below.
 
@@ -1235,18 +1236,18 @@ Remove bindings using @code{mouse-2}.
 @item @code{anju-reconfigure-main-menu-enable}
 Top-level variable to reconfigure the main menu.
 
-If @code{anju-reconfigure-main-menu-enable} is @code{t}, the following variables determine how the main menu is reconfigured:
+If @code{anju-reconfigure-main-menu-enable} is @code{t}@comma{} the following variables determine how the main menu is reconfigured:
 
 @table @asis
 @item @code{anju-reconfigure-main-menu-hook}
-a list of functions, each modifying a menu of the main menu.
+a list of functions@comma{} each modifying a menu of the main menu.
 
 @item @code{anju-help-menu-remove-emacs-tutorial}
 control if the Emacs tutorial menu items are shown.
 @end table
 @end table
 
-By default, all the above @code{*-enable} variables are set to @code{t}.  Users preferring to make granular changes to @code{anju-init} can invoke @code{M-x} @code{customize-group} @code{anju}.
+By default@comma{} all the above @code{*-enable} variables are set to @code{t}.  Users preferring to make granular changes to @code{anju-init} can invoke @code{M-x} @code{customize-group} @code{anju}.
 
 @node Context Menu Customization
 @section Context Menu Customization
@@ -1267,7 +1268,7 @@ Anju uses @code{context-menu-mode} (introduced in Emacs 28) to define its contex
 @code{click} : a mouse event
 @end itemize
 
-When the context menu is raised, typically via right-click (@code{mouse-3}), each function in @code{context-menu-functions} is run, populating the context menu.
+When the context menu is raised@comma{} typically via right-click (@code{mouse-3})@comma{} each function in @code{context-menu-functions} is run@comma{} populating the context menu.
 
 The following example Elisp illustrates an implementation of a context menu function.
 
@@ -1299,7 +1300,7 @@ At the time of menu item definition
 At a higher level.
 @end enumerate
 
-The @emph{context} is determined by a predicate which can take into account different things, among them:
+The @emph{context} is determined by a predicate which can take into account different things@comma{} among them:
 
 @itemize
 @item
@@ -1312,7 +1313,7 @@ Cursor (Point) position
 Mouse position
 @end itemize
 
-In the example above, the context predicate tests if the major mode is derived from @code{text-mode} @emph{and} if point is not inside an Org table (@code{anju-at-org-table-p}).  Note that it is defined at a higher level to avoid instantiating menu items if the context does not apply.
+In the example above@comma{} the context predicate tests if the major mode is derived from @code{text-mode} @emph{and} if point is not inside an Org table (@code{anju-at-org-table-p}).  Note that it is defined at a higher level to avoid instantiating menu items if the context does not apply.
 
 The context predicate can be embedded in the menu item definition itself. See more about this with the @code{:visible} and @code{:active} keywords for the macro @code{easy-menu-define} (@ref{Easy Menu,,,elisp,}).
 
@@ -1395,10 +1396,10 @@ Open in Dired.
 
 @item @code{anju-context-menu-vc}
 Version control related commands.
-If Magit 4.4+ is installed, then calls to it are made from here.
+If Magit 4.4+ is installed@comma{} then calls to it are made from here.
 
 @item @code{anju-context-menu-markup}
-Commands to show/hide text markup (e.g. Org, Markdown).
+Commands to show/hide text markup (e.g. Org@comma{} Markdown).
 
 @item @code{anju-context-menu-wordcount}
 Word count command.
@@ -1438,10 +1439,10 @@ The pop-up buffer list menu can be customized two ways:
 
 @enumerate
 @item
-Customizing the variable @code{anju-buffer-list-filter-functions}, a list of filter functions that are run each time the pop-up menu is raised when left-clicking the mode line buffer name.
+Customizing the variable @code{anju-buffer-list-filter-functions}@comma{} a list of filter functions that are run each time the pop-up menu is raised when left-clicking the mode line buffer name.
 
 @item
-Customizing the variable @code{anju-mode-line-buffer-list-function}, which gives a user complete control on what is displayed in the pop-up menu.
+Customizing the variable @code{anju-mode-line-buffer-list-function}@comma{} which gives a user complete control on what is displayed in the pop-up menu.
 @end enumerate
 
 
@@ -1449,7 +1450,7 @@ Customizing the variable @code{anju-mode-line-buffer-list-function}, which gives
 
 This variable is an alist used by the function @code{anju-buffer-list-menu-items} to populate the list of buffers used in the pop up menu @code{anju-popup-buffer-menu}.
 
-This alist is filled using the following key, value pair types:
+This alist is filled using the following key@comma{} value pair types:
 
 @table @asis
 @item key
@@ -1527,7 +1528,7 @@ Users who wish define their own menu should override this value with their own f
 
 Anju uses the customizable hook variable @code{anju-reconfigure-main-menu-hook} to customize the menu bar.
 
-@code{anju-reconfigure-main-menu-hook} is a list of hook functions,  where each function is designed to modify a different menu of the menu bar (e.g. ``File'', ``Edit'', ``Options'', etc.). This hook is run in the command @code{anju-init}.
+@code{anju-reconfigure-main-menu-hook} is a list of hook functions@comma{}  where each function is designed to modify a different menu of the menu bar (e.g. ``File''@comma{} ``Edit''@comma{} ``Options''@comma{} etc.). This hook is run in the command @code{anju-init}.
 
 Detailed below are the different hook functions provided for by Anju.
 
@@ -1558,13 +1559,13 @@ Anju customizes the @strong{File} menu using the hook function @code{anju-main-m
 
 Add this hook function to @code{anju-reconfigure-main-menu-hook} to enable customization of the @strong{File} menu.
 
-If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}, then a checkbox interface to enable  @code{anju-main-menu--reconfigure-file} is displayed.
+If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}@comma{} then a checkbox interface to enable  @code{anju-main-menu--reconfigure-file} is displayed.
 
 @code{anju-main-menu--reconfigure-file} supports the following customization variable:
 
 @table @asis
 @item @code{anju-file-menu-replace-make-frame-on}
-If non-nil, the following menu items are replaced with more context-specific behavior:
+If non-nil@comma{} the following menu items are replaced with more context-specific behavior:
 
 @itemize
 @item
@@ -1584,7 +1585,7 @@ Anju customizes the @strong{Edit} menu using the hook function @code{anju-main-m
 
 Add this hook function to @code{anju-reconfigure-main-menu-hook} to enable customization of the @strong{Edit} menu.
 
-If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}, then a checkbox interface to enable  @code{anju-main-menu--reconfigure-edit} is displayed.
+If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}@comma{} then a checkbox interface to enable  @code{anju-main-menu--reconfigure-edit} is displayed.
 
 @node Options Menu Customization
 @subsection Options Menu Customization
@@ -1596,7 +1597,7 @@ Anju customizes the @strong{Options} menu using the hook function @code{anju-mai
 
 Add this hook function to @code{anju-reconfigure-main-menu-hook} to enable customization of the @strong{Options} menu.
 
-If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}, then a checkbox interface to enable  @code{anju-main-menu--reconfigure-options} is displayed.
+If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}@comma{} then a checkbox interface to enable  @code{anju-main-menu--reconfigure-options} is displayed.
 
 @node Text Menu Customization
 @subsection Text Menu Customization
@@ -1608,7 +1609,7 @@ Anju customizes the @strong{Text} menu using the hook function @code{anju-main-m
 
 Add this hook function to @code{anju-reconfigure-main-menu-hook} to enable customization of the @strong{Text} menu.
 
-If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}, then a checkbox interface to enable  @code{anju-main-menu--reconfigure-text-mode} is displayed.
+If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}@comma{} then a checkbox interface to enable  @code{anju-main-menu--reconfigure-text-mode} is displayed.
 
 Note that the @strong{Text} menu is only displayed when the current major mode is derived from @code{text-mode}.
 
@@ -1622,7 +1623,7 @@ Anju adds the @strong{Bookmarks} menu to the menu bar using the hook function @c
 
 Add this hook function to @code{anju-reconfigure-main-menu-hook} to add the @strong{Bookmarks} menu.
 
-If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}, then a checkbox interface to enable  @code{anju-main-menu--reconfigure-bookmarks} is displayed.
+If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}@comma{} then a checkbox interface to enable  @code{anju-main-menu--reconfigure-bookmarks} is displayed.
 
 @node Help Menu Customization
 @subsection Help Menu Customization
@@ -1635,13 +1636,13 @@ Anju customizes the @strong{Help} menu using the hook function @code{anju-main-m
 
 Add this hook function to @code{anju-reconfigure-main-menu-hook} to enable customization of the @strong{Help} menu.
 
-If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}, then a checkbox interface to enable  @code{anju-main-menu--reconfigure-help} is displayed.
+If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}@comma{} then a checkbox interface to enable  @code{anju-main-menu--reconfigure-help} is displayed.
 
 @code{anju-main-menu--reconfigure-help} supports the following customization variable:
 
 @table @asis
 @item @code{anju-help-menu-remove-emacs-tutorial}
-if non-nil, then remove the Emacs tutorial menu items. (default @code{t})
+if non-nil@comma{} then remove the Emacs tutorial menu items. (default @code{t})
 @end table
 
 @node Imenu Menu Customization
@@ -1654,7 +1655,7 @@ Anju adds the @strong{Index} menu to the menu bar using the hook function @code{
 
 Add this hook function to @code{anju-reconfigure-main-menu-hook} to add the @strong{Index} menu.
 
-If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}, then a checkbox interface to enable  @code{anju-main-menu--reconfigure-imenu} is displayed.
+If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}@comma{} then a checkbox interface to enable  @code{anju-main-menu--reconfigure-imenu} is displayed.
 
 
 Anju's support for Imenu covers the following modes:
@@ -1682,7 +1683,7 @@ Anju customizes the @strong{Tools} menu using the hook function @code{anju-main-
 
 Add this hook function to @code{anju-reconfigure-main-menu-hook} to enable customization of the @strong{Tools} menu.
 
-If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}, then a checkbox interface to enable  @code{anju-main-menu--reconfigure-tools} is displayed.
+If @code{customize-variable} is used to configure @code{anju-reconfigure-main-menu-hook}@comma{} then a checkbox interface to enable  @code{anju-main-menu--reconfigure-tools} is displayed.
 
 @node Future Work
 @chapter Future Work
@@ -1698,7 +1699,7 @@ Support for more built-in modes
 Further changes to the main menu
 @end itemize
 
-Although much consideration on both the user and developer experience has been made, they are both subject to change in future releases if a better approach presents itself.
+Although much consideration on both the user and developer experience has been made@comma{} they are both subject to change in future releases if a better approach presents itself.
 
 @node Feedback & Discussion
 @chapter Feedback & Discussion
@@ -1707,14 +1708,14 @@ Although much consideration on both the user and developer experience has been m
 Please report any feedback about Anju to the @uref{https://github.com/kickingvegas/anju/issues, issue tracker on GitHub}.
 
 @cindex Discussion
-To participate in general discussion about using Anju, please join the @uref{https://github.com/kickingvegas/anju/discussions, discussion group}.
+To participate in general discussion about using Anju@comma{} please join the @uref{https://github.com/kickingvegas/anju/discussions, discussion group}.
 
 @node Sponsorship
 @chapter Sponsorship
 
 @cindex Sponsorship
 
-It costs money to make, enhance, and maintain Anju as ideologically free software. If you enjoy using Anju, please buy me a coffee to help support its development and maintenance.
+It costs money to make@comma{} enhance@comma{} and maintain Anju as ideologically free software. If you enjoy using Anju@comma{} please buy me a coffee to help support its development and maintenance.
 
 @image{images/default-yellow,,,,png}
 
@@ -1725,7 +1726,7 @@ It costs money to make, enhance, and maintain Anju as ideologically free softwar
 
 @cindex About Anju
 
-@uref{https://github.com/kickingvegas/anju, Anju} was conceived and crafted by Charles Choi in San Francisco, California.
+@uref{https://github.com/kickingvegas/anju, Anju} was conceived and crafted by Charles Choi in San Francisco@comma{} California.
 
 Thank you for using Anju.
 
@@ -1736,7 +1737,7 @@ Always choose love.
 
 @cindex Acknowledgments
 
-Thanks goes out to the contributors to @code{mouse.el}, whose work this package builds upon.
+Thanks goes out to the contributors to @code{mouse.el}@comma{} whose work this package builds upon.
 
 @node Main Index
 @chapter Main Index
@@ -1748,7 +1749,7 @@ Index for this user guide.
 @node Variable Index
 @chapter Variable Index
 
-Variables, functions, commands, and menus referenced by this user guide.
+Variables@comma{} functions@comma{} commands@comma{} and menus referenced by this user guide.
 
 @printindex vr
 

--- a/docs/anju.texi
+++ b/docs/anju.texi
@@ -20,7 +20,7 @@ Copyright © 2026 Charles Y@. Choi
 @finalout
 @titlepage
 @title Anju User Guide
-@subtitle for version 1.5.0
+@subtitle for version 1.5.1-rc.1
 @author Charles Y@. Choi (@email{kickingvegas@@gmail.com})
 @page
 @vskip 0pt plus 1filll
@@ -33,7 +33,7 @@ Copyright © 2026 Charles Y@. Choi
 @node Top
 @top Anju User Guide
 
-Version: 1.5.0
+Version: 1.5.1-rc.1
 
 Copyright © 2026 @w{Charles Y. Choi}
 

--- a/lisp/anju-context-menu.el
+++ b/lisp/anju-context-menu.el
@@ -240,6 +240,13 @@ Return t if populated, nil otherwise."
       t
     nil))
 
+(defun anju-org-element-empty-p ()
+  "Predicate for Org body text to check it is not empty."
+  (let* ((element (org-element-at-point))
+         (c-beg (org-element-property :contents-begin element))
+         (c-end (org-element-property :contents-end element)))
+    (not (and c-beg c-end (> c-end c-beg)))))
+
 (easy-menu-define anju-org-table-region-menu nil
   "Key map for Org table region sub-menu."
   '("Org Table Region"
@@ -437,12 +444,16 @@ outline tree"])
         (easy-menu-add-item menu nil [org-toggle-heading
                                       org-toggle-heading
                                       :label "Change to Heading"
+                                      :visible (and (not (use-region-p))
+                                                    (not (anju-org-element-empty-p)))
                                       :help "Convert headings to normal text, \
 or items or text to headings"])
 
         (easy-menu-add-item menu nil [org-toggle-item
                                       org-toggle-item
                                       :label "Change to Item"
+                                      :visible (and (not (use-region-p))
+                                                    (not (anju-org-element-empty-p)))
                                       :help "Convert headings or normal lines \
 to items, items to normal lines"])))
 

--- a/lisp/anju-context-menu.el
+++ b/lisp/anju-context-menu.el
@@ -44,8 +44,7 @@
 (require 'casual-make)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Dired
+;;; Context Menu: Dired
 
 (defun anju-dired-duplicate-file ()
   "Duplicate the current file in Dired."
@@ -201,8 +200,7 @@ file names in the Dired buffer"])
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Scratch Buffer
+;;; Context Menu: Scratch Buffer
 
 (defun anju-context-menu-scratch (menu click)
   "Context menu hook function for journal commands.
@@ -224,8 +222,7 @@ This function is intended to be hooked into `context-menu-functions'."
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Org Mode
+;;; Context Menu: Org Mode
 
 (defun anju-at-org-table-p ()
   "Predicate if point is in an Org table."
@@ -467,8 +464,7 @@ to items, items to normal lines"])))
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Info Mode
+;;; Context Menu: Info Mode
 
 
 (defun anju-info-goto-node-web ()
@@ -536,8 +532,7 @@ node into the kill ring"])
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Emacs Lisp Mode
+;;; Context Menu: Emacs Lisp Mode
 
 
 (defun anju-form-name-at-point ()
@@ -877,8 +872,7 @@ a reference to the new defun ARG."
     (message "not on lambda")))
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Buffer Navigation/Management
+;;; Context Menu: Buffer Navigation/Management
 
 (defun anju-context-menu-buffers (menu click)
   "Context menu hook function for buffers commands.
@@ -910,8 +904,7 @@ This function is intended to be hooked into `context-menu-functions'."
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Narrow/Widen
+;;; Context Menu: Narrow/Widen
 
 (defun anju-context-menu-narrow (menu click)
   "Context menu hook function for narrow commands.
@@ -965,8 +958,7 @@ from current buffer"]))))
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Open in…
+;;; Context Menu: Open in…
 
 (defun anju-context-menu-open-in (menu click)
   "Context menu hook function for open-in commands.
@@ -991,8 +983,7 @@ This function is intended to be hooked into `context-menu-functions'."
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: VC/Magit
+;;; Context Menu: VC/Magit
 
 (defun anju-context-menu-vc (menu click)
   "Context menu hook function for version control commands.
@@ -1037,8 +1028,7 @@ This function is intended to be hooked into `context-menu-functions'."
 
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Region Operations
+;;; Context Menu: Region Operations
 
 (defun anju-occur-selected-region ()
   "Occur selected region."
@@ -1099,8 +1089,7 @@ containing a match for selected word"])
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Region Extension
+;;; Context Menu: Region Extension
 
 (defun anju-yank-media-p ()
   "Predicate if media (images, HTML and the like) is in the clipboard.
@@ -1270,8 +1259,7 @@ URL `https://gist.github.com/danielmartin/3c5d3a3a8cd24a3556379c5251651748'."
 
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Compilation Mode
+;;; Context Menu: Compilation Mode
 
 (defun anju-context-menu-compile (menu click)
   "Context menu hook function for compile commands.
@@ -1316,8 +1304,7 @@ buffer.  Default: run ‘make’"])
 
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Show Markup/Toggle Images
+;;; Context Menu: Show Markup/Toggle Images
 
 (defun anju-context-menu-markup (menu click)
   "Context menu hook function for markup commands.
@@ -1362,8 +1349,7 @@ temporarily visible (Visible mode)"]))
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Word Count
+;;; Context Menu: Word Count
 
 (defun anju-context-menu-wordcount (menu click)
   "Context menu hook function for wordcount commands.
@@ -1384,8 +1370,7 @@ This function is intended to be hooked into `context-menu-functions'."
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Dictionary
+;;; Context Menu: Dictionary
 
 (defun anju-context-menu-dictionary (menu click)
   "Context menu hook function for the dictionary command.
@@ -1408,8 +1393,7 @@ This function is intended to be hooked into `context-menu-functions'."
 
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Window Management
+;;; Context Menu: Window Management
 
 (easy-menu-define anju-context-window-management-menu nil
   "Keymap for mouse window management menu."
@@ -1458,8 +1442,7 @@ This function is intended to be hooked into `context-menu-functions'."
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Rectangle Commands
+;;; Context Menu: Rectangle Commands
 
 (defun anju-context-menu-rectangle (menu click)
   "Context menu hook function for wordcount commands.
@@ -1481,8 +1464,7 @@ This function is intended to be hooked into `context-menu-functions'."
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Makefile Mode
+;;; Context Menu: Makefile Mode
 
 (easy-menu-define anju-makefile-modes-menu nil
   "Keymap for mouse window management menu."
@@ -1626,8 +1608,7 @@ the state of all known targets"])
   menu)
 
 
-;; -------------------------------------------------------------------
-;; Context Menu: Utility and Setup Functions
+;;; Context Menu: Utility and Setup Functions
 
 (defun anju-context-menu--insert-into-context-menu-functions (source target)
   "Insert SOURCE before TARGET in `context-menu-functions'.

--- a/lisp/anju-main-menu.el
+++ b/lisp/anju-main-menu.el
@@ -37,8 +37,7 @@
 (require 'casual-editkit)
 
 
-;; -------------------------------------------------------------------
-;; File Menu Customization
+;;; File Menu Customization
 (easy-menu-define anju-window-swap-menu nil
   "Keymap for mouse window swap menu."
   '("Swap Window"
@@ -94,8 +93,7 @@ This function is intended to be used in
                         'delete-this-frame)))
 
 
-;; -------------------------------------------------------------------
-;; Options Menu Customization
+;;; Options Menu Customization
 (defun anju-main-menu--reconfigure-options ()
   "Hook function to reconfigure Options menu in main menu bar.
 
@@ -105,8 +103,7 @@ This function is intended to be used in
 
 
 
-;; -------------------------------------------------------------------
-;; Edit Menu Customization
+;;; Edit Menu Customization
 (easy-menu-define anju-transpose-menu nil
   "Keymap for Transpose menu."
   '("Transpose ⇄"
@@ -274,8 +271,7 @@ read from the minibuffer"
 
 
 
-;; -------------------------------------------------------------------
-;; Reconfigure Bookmarks Menu
+;;; Reconfigure Bookmarks Menu
 (defun anju-main-menu--reconfigure-bookmarks ()
   "Hook function to add Bookmarks menu to the main menu bar.
 
@@ -289,8 +285,7 @@ This function is intended to be used in
 
 
 
-;; -------------------------------------------------------------------
-;; Help Menu Customization
+;;; Help Menu Customization
 
 (defun anju-info-in-new-frame ()
   "Create new frame with `info' window."
@@ -398,8 +393,7 @@ This function is intended to be used in
 
 
 
-;; -------------------------------------------------------------------
-;; Text Mode Menu Customization
+;;; Text Mode Menu Customization
 
 (defun anju-main-menu--reconfigure-text-mode ()
   "Reconfigure Text mode menu."
@@ -415,8 +409,7 @@ This function is intended to be used in
   (easy-menu-add-item text-mode-menu nil anju-fill-text-menu "Auto Fill"))
 
 
-;; -------------------------------------------------------------------
-;; Imenu Configuration
+;;; Imenu Configuration
 
 (defun anju-imenu-add-menubar-index ()
   "Add imenu index to menubar."
@@ -459,8 +452,7 @@ Auto rescan `imenu-auto-rescan' is enabled for all affected modes."
         (setopt org-imenu-depth 7))))
 
 
-;; -------------------------------------------------------------------
-;; Tools Menu Customization
+;;; Tools Menu Customization
 
 (easy-menu-define anju-kmacro-menu nil
   "Keymap for keyboard macro commands."

--- a/lisp/anju-mode-line.el
+++ b/lisp/anju-mode-line.el
@@ -44,8 +44,7 @@ function."
   :group 'anju)
 
 
-;; -------------------------------------------------------------------
-;; Mode Line Customization
+;;; Mode Line Customization
 
 (easy-menu-define anju-window-management-menu nil
   "Keymap for mouse window management menu."
@@ -103,8 +102,7 @@ Derived from code found at URL
   (popup-menu (funcall anju-mode-line-buffer-list-function) click))
 
 
-;; -------------------------------------------------------------------
-;; Buffer Filter Logic
+;;; Buffer Filter Logic
 
 (defun anju-buffer-list--filter (filter buffers &optional count)
   "Apply FILTER on BUFFERS, taking the first COUNT if defined."

--- a/lisp/anju-utils.el
+++ b/lisp/anju-utils.el
@@ -379,8 +379,7 @@ conform to extent <= (max/2) - 2"
      :help "Delete all whitespace following a specified column in each line"]))
 
 
-;; -------------------------------------------------------------------
-;; Delete Window Logic
+;;; Delete Window Logic
 
 (defun anju--scrub-frame-register-list ()
   "Scrub `anju--frame-register-alist'."

--- a/lisp/anju.el
+++ b/lisp/anju.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <charles.choi@yummymelon.com>
 ;; URL: https://github.com/kickingvegas/anju
 ;; Keywords: tools
-;; Version: 1.5.0
+;; Version: 1.5.1-rc.1
 ;; Package-Requires: ((emacs "29.1") (casual "2.14.0") (markdown-mode "2.7"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/lisp/anju.el
+++ b/lisp/anju.el
@@ -37,22 +37,39 @@
 
 ;; INSTALLATION
 
-;; Basic installation of Anju composes of two parts:
-
-;; 1. Turn on `context-menu-mode' to major modes of preference. This is done
-;;    using the `add-hook' function as shown below.
-
-;;     (add-hook 'prog-mode-hook #'context-menu-mode)
-;;     (add-hook 'text-mode-hook #'context-menu-mode)
-;;     (add-hook 'dired-mode-hook #'context-menu-mode)
-;;     (add-hook 'shell-mode-hook #'context-menu-mode)
-
-;; 2. Call `anju-init' in your Emacs initialization file.
+;; To install Anju, add the command `anju-init' to your Emacs initialization
+;; file.
 
 ;;     (anju-init)
 
-;; The `anju-init' command can be customized to preference. Read more on this in
-;; the Anju User Guide in Info.
+;; This command will initialize `context-menu-mode' and reconfigure the
+;; following mouse menus and bindings:
+
+;; - Legacy mouse bindings
+;; - Mode line bindings
+;; - Main menu
+;; - Context menus for different modes
+
+;; The `anju-init' command can be customized to preference. See Info node
+;; `(anju) Anju Initialization (anju-init)' for more detail.
+
+;; While not required, the following additions to your Emacs initialization
+;; file can further enhance your mouse experience:
+
+;; - Enable `org-mouse'
+
+;;     (require 'org-mouse)
+
+;; - Add Markdown export support to Org mode
+;;   - `M-x' `customize-variable' `org-export-backends', check `md' option.
+
+;; - Globally bind `C-x 1' to `anju-toggle-one-window'.
+
+;;     (keymap-global-set "C-x 1" #'anju-toggle-one-window)
+
+;; - Set `use-file-dialog' to `t' to support mouse-driven-only dialog
+;;   interactions, or `nil' to always get a mini-buffer prompt.
+
 
 ;;; Code:
 (require 'anju-mode-line)
@@ -73,12 +90,19 @@ of mouse menus and bindings:
 - Legacy mouse bindings (`anju-unset-legacy-mouse-bindings-enable')
 - Mode line bindings (`anju-mode-line-bindings-enable')
 - Main menu (`anju-reconfigure-main-menu-enable')
-- Context menu (`anju-reconfigure-context-menu-functions-enable')
+- Context menus (`anju-reconfigure-context-menu-functions-enable')
 
 Each area is controlled with a customizable variable and all are by
 default t. Changes to any of these variables will require a restart of
-Emacs."
+Emacs.
+
+The global minor mode `context-menu-mode' will be initialized if it
+already has not been done so."
   (interactive)
+
+  (unless context-menu-mode
+    (context-menu-mode 1))
+
   (if anju-unset-legacy-mouse-bindings-enable
       (anju-utils--unset-legacy-mouse-bindings))
 

--- a/lisp/anju.el
+++ b/lisp/anju.el
@@ -77,8 +77,7 @@
 (require 'anju-context-menu)
 
 
-;; -------------------------------------------------------------------
-;; Initialization Routines
+;;; Initialization Routines
 
 ;;;###autoload (autoload 'anju-init "anju" nil t)
 (defun anju-init ()


### PR DESCRIPTION
- **Bump version to 1.5.1-rc.1**
  

- **Streamline Anju initialization**
  - Fix guidance to _not_ configure `context-menu-mode` on a per-mode basis.
  - Push `context-menu-mode` loading into `anju-init`.
  - Amend documentation accordingly.
  

- **Fix predicates for org-toggle-heading and org-toggle-item**
  Fix predicates for org-toggle-heading and org-toggle-item to not display when:
  
  - A region is selected, or
  - There is no element text
  

- **Fix page separators**
  - Fix page separators to conform to page-directory
  