### PR TITLE
Do not show window sub-menu in context menu if region is selected

### DIFF
--- a/lisp/anju-context-menu.el
+++ b/lisp/anju-context-menu.el
@@ -1761,7 +1761,7 @@ This hook is intended for `context-menu-functions'."
 - CLICK: event
 
 This hook is intended for `context-menu-functions'."
-  (save-excursion
+  (when (not (use-region-p))
     (anju-context-menu-item-separator menu context-window--separator)
     (easy-menu-add-item menu nil anju-context-window-management-menu))
   menu)


### PR DESCRIPTION
* lisp/anju-context-menu.el (anju-context-menu-window): Add use-region-p
predicate to anju-context-menu-window.
